### PR TITLE
feat: API ergonomics — Selector, GridCell, ScaleBuilder

### DIFF
--- a/examples/anim2.rs
+++ b/examples/anim2.rs
@@ -10,7 +10,7 @@ use oxivgl::{
     view::View,
     widgets::{
         anim_path_ease_in_out, anim_set_size, anim_set_x, palette_main, Align, Anim, Obj, Palette,
-        Screen, WidgetError, ANIM_REPEAT_INFINITE,
+        Screen, Selector, WidgetError, ANIM_REPEAT_INFINITE, RADIUS_MAX,
     },
 };
 
@@ -24,8 +24,8 @@ impl View for Anim2 {
 
         let obj = Obj::new(&screen)?;
         obj.remove_scrollable();
-        obj.style_bg_color(palette_main(Palette::Red), 0);
-        obj.radius(0x7fff, 0);
+        obj.style_bg_color(palette_main(Palette::Red), Selector::DEFAULT);
+        obj.radius(RADIUS_MAX, Selector::DEFAULT);
         obj.align(Align::LeftMid, 10, 0);
 
         let mut a = Anim::new();

--- a/examples/event_bubble.rs
+++ b/examples/event_bubble.rs
@@ -13,8 +13,8 @@
 use oxivgl::{
     view::{register_event_on, View},
     widgets::{
-        Button, Event, EventCode, FlexFlow, Label, Obj, Palette, Screen, WidgetError,
-        palette_main,
+        palette_main, Button, Event, EventCode, FlexFlow, Label, Obj, Palette, Screen, Selector,
+        WidgetError,
     },
 };
 
@@ -31,7 +31,9 @@ impl View for EventBubble {
         // TODO: No touch input on fire27 hardware — click events won't fire
         // until an input device is connected.
         #[cfg(target_arch = "xtensa")]
-        oxivgl_examples_common::warn!("event_bubble: no touch input — click events require input device");
+        oxivgl_examples_common::warn!(
+            "event_bubble: no touch input — click events require input device"
+        );
 
         let cont = Obj::new(&screen)?;
         cont.size(290, 200).center();
@@ -73,7 +75,7 @@ impl View for EventBubble {
         if target == self.cont.handle() {
             return;
         }
-        event.target_style_bg_color(palette_main(Palette::Red), 0);
+        event.target_style_bg_color(palette_main(Palette::Red), Selector::DEFAULT);
     }
 
     fn update(&mut self) -> Result<(), WidgetError> {

--- a/examples/event_trickle.rs
+++ b/examples/event_trickle.rs
@@ -35,16 +35,20 @@ impl View for EventTrickle {
         // TODO: No touch input on fire27 hardware — press/focus events won't
         // fire until an input device is connected.
         #[cfg(target_arch = "xtensa")]
-        oxivgl_examples_common::warn!("event_trickle: no touch input — press events require input device");
+        oxivgl_examples_common::warn!(
+            "event_trickle: no touch input — press events require input device"
+        );
 
         let mut style_black = Box::new(Style::new());
-        style_black.text_color(color_white()).bg_color(color_black());
+        style_black
+            .text_color(color_white())
+            .bg_color(color_black());
 
         let cont = Obj::new(&screen)?;
         cont.size(290, 200).center();
         cont.set_flex_flow(FlexFlow::RowWrap);
         cont.add_flag(ObjFlag::EVENT_TRICKLE);
-        cont.add_style(&style_black, ObjState::PRESSED.0);
+        cont.add_style(&style_black, ObjState::PRESSED);
 
         let mut subconts = heapless::Vec::<Obj<'static>, 9>::new();
         let mut labels = heapless::Vec::<Label<'static>, 9>::new();
@@ -52,7 +56,7 @@ impl View for EventTrickle {
         for i in 0..9u32 {
             let subcont = Obj::new(&cont)?;
             subcont.size(70, 50);
-            subcont.add_style(&style_black, ObjState::FOCUSED.0);
+            subcont.add_style(&style_black, ObjState::FOCUSED);
 
             let label = Label::new(&subcont)?;
             let mut buf = heapless::String::<4>::new();

--- a/examples/flex2.rs
+++ b/examples/flex2.rs
@@ -9,7 +9,7 @@
 use oxivgl::{
     view::View,
     widgets::{
-        FlexAlign, FlexFlow, Label, Layout, Obj, ObjFlag, Screen, Style, WidgetError,
+        FlexAlign, FlexFlow, Label, Layout, Obj, ObjFlag, Screen, Selector, Style, WidgetError,
         LV_SIZE_CONTENT,
     },
 };
@@ -33,7 +33,7 @@ impl View for Flex2 {
 
         let cont = Obj::new(&screen)?;
         cont.size(300, 220).center();
-        cont.add_style(&style, 0);
+        cont.add_style(&style, Selector::DEFAULT);
 
         let mut items = heapless::Vec::<Obj<'static>, 8>::new();
         let mut labels = heapless::Vec::<Label<'static>, 8>::new();

--- a/examples/flex6.rs
+++ b/examples/flex6.rs
@@ -8,7 +8,7 @@
 
 use oxivgl::{
     view::View,
-    widgets::{BaseDir, FlexFlow, Label, Obj, Screen, WidgetError, LV_SIZE_CONTENT},
+    widgets::{BaseDir, FlexFlow, Label, Obj, Screen, Selector, WidgetError, LV_SIZE_CONTENT},
 };
 
 struct Flex6 {
@@ -22,7 +22,7 @@ impl View for Flex6 {
         let screen = Screen::active().ok_or(WidgetError::LvglNullPointer)?;
 
         let cont = Obj::new(&screen)?;
-        cont.set_style_base_dir(BaseDir::Rtl, 0);
+        cont.set_style_base_dir(BaseDir::Rtl, Selector::DEFAULT);
         cont.size(300, 220).center();
         cont.set_flex_flow(FlexFlow::RowWrap);
 

--- a/examples/getting_started3.rs
+++ b/examples/getting_started3.rs
@@ -13,7 +13,7 @@ use oxivgl::{
     view::View,
     widgets::{
         darken_filter_cb, palette_lighten, palette_main, Button, ColorFilter, GradDir, Label,
-        ObjState, Opa, Palette, Screen, Style, WidgetError,
+        ObjState, Opa, Palette, Screen, Selector, Style, WidgetError, RADIUS_MAX,
     },
 };
 
@@ -56,18 +56,18 @@ impl View for GettingStarted3 {
 
         let btn1 = Button::new(&screen)?;
         btn1.remove_style_all().pos(10, 10).size(120, 50);
-        btn1.add_style(&style_btn, 0);
-        btn1.add_style(&style_pressed, ObjState::PRESSED.0);
+        btn1.add_style(&style_btn, Selector::DEFAULT);
+        btn1.add_style(&style_pressed, ObjState::PRESSED);
 
         let lbl1 = Label::new(&btn1)?;
         lbl1.text("Button").center();
 
         let btn2 = Button::new(&screen)?;
         btn2.remove_style_all().pos(10, 80).size(120, 50);
-        btn2.add_style(&style_btn, 0);
-        btn2.add_style(&style_red, 0);
-        btn2.add_style(&style_pressed, ObjState::PRESSED.0);
-        btn2.radius(0x7fff, 0);
+        btn2.add_style(&style_btn, Selector::DEFAULT);
+        btn2.add_style(&style_red, Selector::DEFAULT);
+        btn2.add_style(&style_pressed, ObjState::PRESSED);
+        btn2.radius(RADIUS_MAX, Selector::DEFAULT);
 
         let lbl2 = Label::new(&btn2)?;
         lbl2.text("Button 2").center();

--- a/examples/grid1.rs
+++ b/examples/grid1.rs
@@ -8,7 +8,7 @@
 
 use oxivgl::{
     view::View,
-    widgets::{Button, GridAlign, Label, Screen, WidgetError, GRID_TEMPLATE_LAST},
+    widgets::{Button, GridAlign, GridCell, Label, Screen, WidgetError, GRID_TEMPLATE_LAST},
 };
 
 static COL_DSC: [i32; 4] = [70, 70, 70, GRID_TEMPLATE_LAST];
@@ -37,12 +37,8 @@ impl View for Grid1 {
 
             let btn = Button::new(&cont)?;
             btn.set_grid_cell(
-                GridAlign::Stretch,
-                col,
-                1,
-                GridAlign::Stretch,
-                row,
-                1,
+                GridCell::new(GridAlign::Stretch, col, 1),
+                GridCell::new(GridAlign::Stretch, row, 1),
             );
 
             let label = Label::new(&btn)?;

--- a/examples/grid2.rs
+++ b/examples/grid2.rs
@@ -8,7 +8,9 @@
 
 use oxivgl::{
     view::View,
-    widgets::{GridAlign, Label, Obj, Screen, WidgetError, GRID_TEMPLATE_LAST, LV_SIZE_CONTENT},
+    widgets::{
+        GridAlign, GridCell, Label, Obj, Screen, WidgetError, GRID_TEMPLATE_LAST, LV_SIZE_CONTENT,
+    },
 };
 
 static COL_DSC: [i32; 4] = [70, 70, 70, GRID_TEMPLATE_LAST];
@@ -34,7 +36,10 @@ impl View for Grid2 {
         // Cell 0,0 — START/START
         let obj = Obj::new(&cont)?;
         obj.size(LV_SIZE_CONTENT, LV_SIZE_CONTENT);
-        obj.set_grid_cell(GridAlign::Start, 0, 1, GridAlign::Start, 0, 1);
+        obj.set_grid_cell(
+            GridCell::new(GridAlign::Start, 0, 1),
+            GridCell::new(GridAlign::Start, 0, 1),
+        );
         let lbl = Label::new(&obj)?;
         lbl.text("c0, r0");
         let _ = items.push(obj);
@@ -43,7 +48,10 @@ impl View for Grid2 {
         // Cell 1,0 — START/CENTER
         let obj = Obj::new(&cont)?;
         obj.size(LV_SIZE_CONTENT, LV_SIZE_CONTENT);
-        obj.set_grid_cell(GridAlign::Start, 1, 1, GridAlign::Center, 0, 1);
+        obj.set_grid_cell(
+            GridCell::new(GridAlign::Start, 1, 1),
+            GridCell::new(GridAlign::Center, 0, 1),
+        );
         let lbl = Label::new(&obj)?;
         lbl.text("c1, r0");
         let _ = items.push(obj);
@@ -52,7 +60,10 @@ impl View for Grid2 {
         // Cell 2,0 — START/END
         let obj = Obj::new(&cont)?;
         obj.size(LV_SIZE_CONTENT, LV_SIZE_CONTENT);
-        obj.set_grid_cell(GridAlign::Start, 2, 1, GridAlign::End, 0, 1);
+        obj.set_grid_cell(
+            GridCell::new(GridAlign::Start, 2, 1),
+            GridCell::new(GridAlign::End, 0, 1),
+        );
         let lbl = Label::new(&obj)?;
         lbl.text("c2, r0");
         let _ = items.push(obj);
@@ -61,7 +72,10 @@ impl View for Grid2 {
         // Cell 1-2,1 — spans 2 columns
         let obj = Obj::new(&cont)?;
         obj.size(LV_SIZE_CONTENT, LV_SIZE_CONTENT);
-        obj.set_grid_cell(GridAlign::Stretch, 1, 2, GridAlign::Stretch, 1, 1);
+        obj.set_grid_cell(
+            GridCell::new(GridAlign::Stretch, 1, 2),
+            GridCell::new(GridAlign::Stretch, 1, 1),
+        );
         let lbl = Label::new(&obj)?;
         lbl.text("c1-2, r1");
         let _ = items.push(obj);
@@ -70,7 +84,10 @@ impl View for Grid2 {
         // Cell 0,1-2 — spans 2 rows
         let obj = Obj::new(&cont)?;
         obj.size(LV_SIZE_CONTENT, LV_SIZE_CONTENT);
-        obj.set_grid_cell(GridAlign::Stretch, 0, 1, GridAlign::Stretch, 1, 2);
+        obj.set_grid_cell(
+            GridCell::new(GridAlign::Stretch, 0, 1),
+            GridCell::new(GridAlign::Stretch, 1, 2),
+        );
         let lbl = Label::new(&obj)?;
         lbl.text("c0\nr1-2");
         let _ = items.push(obj);

--- a/examples/grid3.rs
+++ b/examples/grid3.rs
@@ -8,7 +8,7 @@
 
 use oxivgl::{
     view::View,
-    widgets::{GridAlign, Label, Obj, Screen, WidgetError, GRID_TEMPLATE_LAST, grid_fr},
+    widgets::{grid_fr, GridAlign, GridCell, Label, Obj, Screen, WidgetError, GRID_TEMPLATE_LAST},
 };
 
 static COL_DSC: [i32; 4] = [60, grid_fr(1), grid_fr(2), GRID_TEMPLATE_LAST];
@@ -37,12 +37,8 @@ impl View for Grid3 {
 
             let obj = Obj::new(&cont)?;
             obj.set_grid_cell(
-                GridAlign::Stretch,
-                col,
-                1,
-                GridAlign::Stretch,
-                row,
-                1,
+                GridCell::new(GridAlign::Stretch, col, 1),
+                GridCell::new(GridAlign::Stretch, row, 1),
             );
 
             let label = Label::new(&obj)?;

--- a/examples/grid4.rs
+++ b/examples/grid4.rs
@@ -8,7 +8,7 @@
 
 use oxivgl::{
     view::View,
-    widgets::{GridAlign, Label, Obj, Screen, WidgetError, GRID_TEMPLATE_LAST},
+    widgets::{GridAlign, GridCell, Label, Obj, Screen, WidgetError, GRID_TEMPLATE_LAST},
 };
 
 static COL_DSC: [i32; 4] = [60, 60, 60, GRID_TEMPLATE_LAST];
@@ -38,12 +38,8 @@ impl View for Grid4 {
 
             let obj = Obj::new(&cont)?;
             obj.set_grid_cell(
-                GridAlign::Stretch,
-                col,
-                1,
-                GridAlign::Stretch,
-                row,
-                1,
+                GridCell::new(GridAlign::Stretch, col, 1),
+                GridCell::new(GridAlign::Stretch, row, 1),
             );
 
             let label = Label::new(&obj)?;

--- a/examples/grid5.rs
+++ b/examples/grid5.rs
@@ -9,8 +9,8 @@
 use oxivgl::{
     view::View,
     widgets::{
-        anim_set_pad_column, anim_set_pad_row, Anim, GridAlign, Label, Obj, Screen, WidgetError,
-        ANIM_REPEAT_INFINITE, GRID_TEMPLATE_LAST,
+        anim_set_pad_column, anim_set_pad_row, Anim, GridAlign, GridCell, Label, Obj, Screen,
+        WidgetError, ANIM_REPEAT_INFINITE, GRID_TEMPLATE_LAST,
     },
 };
 
@@ -40,12 +40,8 @@ impl View for Grid5 {
 
             let obj = Obj::new(&cont)?;
             obj.set_grid_cell(
-                GridAlign::Stretch,
-                col,
-                1,
-                GridAlign::Stretch,
-                row,
-                1,
+                GridCell::new(GridAlign::Stretch, col, 1),
+                GridCell::new(GridAlign::Stretch, row, 1),
             );
 
             let label = Label::new(&obj)?;

--- a/examples/grid6.rs
+++ b/examples/grid6.rs
@@ -8,7 +8,9 @@
 
 use oxivgl::{
     view::View,
-    widgets::{BaseDir, GridAlign, Label, Obj, Screen, WidgetError, GRID_TEMPLATE_LAST},
+    widgets::{
+        BaseDir, GridAlign, GridCell, Label, Obj, Screen, Selector, WidgetError, GRID_TEMPLATE_LAST,
+    },
 };
 
 static COL_DSC: [i32; 4] = [60, 60, 60, GRID_TEMPLATE_LAST];
@@ -26,7 +28,7 @@ impl View for Grid6 {
 
         let cont = Obj::new(&screen)?;
         cont.size(300, 220).center();
-        cont.set_style_base_dir(BaseDir::Rtl, 0);
+        cont.set_style_base_dir(BaseDir::Rtl, Selector::DEFAULT);
         cont.set_grid_dsc_array(&COL_DSC, &ROW_DSC);
 
         let mut items = heapless::Vec::<Obj<'static>, 9>::new();
@@ -38,12 +40,8 @@ impl View for Grid6 {
 
             let obj = Obj::new(&cont)?;
             obj.set_grid_cell(
-                GridAlign::Stretch,
-                col,
-                1,
-                GridAlign::Stretch,
-                row,
-                1,
+                GridCell::new(GridAlign::Stretch, col, 1),
+                GridCell::new(GridAlign::Stretch, row, 1),
             );
 
             let label = Label::new(&obj)?;

--- a/examples/style1.rs
+++ b/examples/style1.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(target_arch = "xtensa", no_std, no_main)]
-#![cfg_attr(target_arch = "xtensa", feature(impl_trait_in_assoc_type, type_alias_impl_trait))]
+#![cfg_attr(
+    target_arch = "xtensa",
+    feature(impl_trait_in_assoc_type, type_alias_impl_trait)
+)]
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //! Style 1 — Size, Position and Padding
 
@@ -8,7 +11,7 @@ extern crate alloc;
 use alloc::boxed::Box;
 use oxivgl::{
     view::View,
-    widgets::{LV_SIZE_CONTENT, Label, Obj, Screen, Style, WidgetError, lv_pct},
+    widgets::{lv_pct, Label, Obj, Screen, Selector, Style, WidgetError, LV_SIZE_CONTENT},
 };
 
 struct Style1 {
@@ -32,7 +35,7 @@ impl View for Style1 {
             .y(80);
 
         let obj = Obj::new(&screen)?;
-        obj.add_style(&style, 0);
+        obj.add_style(&style, Selector::DEFAULT);
 
         let label = Label::new(&obj)?;
         label.text("Hello");

--- a/examples/style10.rs
+++ b/examples/style10.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(target_arch = "xtensa", no_std, no_main)]
-#![cfg_attr(target_arch = "xtensa", feature(impl_trait_in_assoc_type, type_alias_impl_trait))]
+#![cfg_attr(
+    target_arch = "xtensa",
+    feature(impl_trait_in_assoc_type, type_alias_impl_trait)
+)]
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //! Style 10 — Transition
 
@@ -9,8 +12,8 @@ use alloc::boxed::Box;
 use oxivgl::{
     view::View,
     widgets::{
-        Obj, ObjState, Palette, Screen, Style, TransitionDsc, WidgetError, anim_path_linear,
-        palette_darken, palette_main, props,
+        anim_path_linear, palette_darken, palette_main, props, Obj, ObjState, Palette, Screen,
+        Selector, Style, TransitionDsc, WidgetError,
     },
 };
 
@@ -22,12 +25,8 @@ struct Style10 {
     _trans_pr: Box<TransitionDsc>,
 }
 
-static TRANS_PROPS: [props::lv_style_prop_t; 4] = [
-    props::BG_COLOR,
-    props::BORDER_COLOR,
-    props::BORDER_WIDTH,
-    0,
-];
+static TRANS_PROPS: [props::lv_style_prop_t; 4] =
+    [props::BG_COLOR, props::BORDER_COLOR, props::BORDER_WIDTH, 0];
 
 impl View for Style10 {
     fn create() -> Result<Self, WidgetError> {
@@ -58,8 +57,8 @@ impl View for Style10 {
             .transition(&trans_pr);
 
         let obj = Obj::new(&screen)?;
-        obj.add_style(&style_def, 0);
-        obj.add_style(&style_pr, ObjState::PRESSED.0);
+        obj.add_style(&style_def, Selector::DEFAULT);
+        obj.add_style(&style_pr, ObjState::PRESSED);
         obj.center();
 
         Ok(Self {

--- a/examples/style11.rs
+++ b/examples/style11.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(target_arch = "xtensa", no_std, no_main)]
-#![cfg_attr(target_arch = "xtensa", feature(impl_trait_in_assoc_type, type_alias_impl_trait))]
+#![cfg_attr(
+    target_arch = "xtensa",
+    feature(impl_trait_in_assoc_type, type_alias_impl_trait)
+)]
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //! Style 11 — Multiple styles
 
@@ -9,8 +12,8 @@ use alloc::boxed::Box;
 use oxivgl::{
     view::View,
     widgets::{
-        Align, LV_SIZE_CONTENT, Label, Obj, Palette, Screen, Style, WidgetError, color_white,
-        palette_darken, palette_main,
+        color_white, palette_darken, palette_main, Align, Label, Obj, Palette, Screen, Selector,
+        Style, WidgetError, LV_SIZE_CONTENT,
     },
 };
 
@@ -47,15 +50,15 @@ impl View for Style11 {
             .text_color(palette_darken(Palette::Yellow, 4));
 
         let obj_base = Obj::new(&screen)?;
-        obj_base.add_style(&style_base, 0);
+        obj_base.add_style(&style_base, Selector::DEFAULT);
         obj_base.align(Align::LeftMid, 20, 0);
 
         let label_base = Label::new(&obj_base)?;
         label_base.text("Base").center();
 
         let obj_warn = Obj::new(&screen)?;
-        obj_warn.add_style(&style_base, 0);
-        obj_warn.add_style(&style_warning, 0);
+        obj_warn.add_style(&style_base, Selector::DEFAULT);
+        obj_warn.add_style(&style_warning, Selector::DEFAULT);
         obj_warn.align(Align::RightMid, -20, 0);
 
         let label_warn = Label::new(&obj_warn)?;

--- a/examples/style12.rs
+++ b/examples/style12.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(target_arch = "xtensa", no_std, no_main)]
-#![cfg_attr(target_arch = "xtensa", feature(impl_trait_in_assoc_type, type_alias_impl_trait))]
+#![cfg_attr(
+    target_arch = "xtensa",
+    feature(impl_trait_in_assoc_type, type_alias_impl_trait)
+)]
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //! Style 12 — Local styles
 
@@ -8,7 +11,7 @@ extern crate alloc;
 use alloc::boxed::Box;
 use oxivgl::{
     view::View,
-    widgets::{Obj, Palette, Screen, Style, WidgetError, palette_lighten, palette_main},
+    widgets::{palette_lighten, palette_main, Obj, Palette, Screen, Selector, Style, WidgetError},
 };
 
 struct Style12 {
@@ -27,8 +30,8 @@ impl View for Style12 {
             .border_width(3);
 
         let obj = Obj::new(&screen)?;
-        obj.add_style(&style, 0);
-        obj.style_bg_color(palette_main(Palette::Orange), 0);
+        obj.add_style(&style, Selector::DEFAULT);
+        obj.style_bg_color(palette_main(Palette::Orange), Selector::DEFAULT);
         obj.center();
 
         Ok(Self {

--- a/examples/style13.rs
+++ b/examples/style13.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(target_arch = "xtensa", no_std, no_main)]
-#![cfg_attr(target_arch = "xtensa", feature(impl_trait_in_assoc_type, type_alias_impl_trait))]
+#![cfg_attr(
+    target_arch = "xtensa",
+    feature(impl_trait_in_assoc_type, type_alias_impl_trait)
+)]
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //! Style 13 — Parts and states
 
@@ -9,8 +12,8 @@ use alloc::boxed::Box;
 use oxivgl::{
     view::View,
     widgets::{
-        GradDir, ObjState, Palette, Part, Screen, Slider, Style, WidgetError, palette_lighten,
-        palette_main,
+        palette_lighten, palette_main, GradDir, ObjState, Palette, Part, Screen, Slider, Style,
+        WidgetError,
     },
 };
 
@@ -37,8 +40,8 @@ impl View for Style13 {
             .shadow_spread(3);
 
         let slider = Slider::new(&screen)?;
-        slider.add_style(&style_indic, Part::Indicator as u32);
-        slider.add_style(&style_indic_pr, Part::Indicator as u32 | ObjState::PRESSED.0);
+        slider.add_style(&style_indic, Part::Indicator);
+        slider.add_style(&style_indic_pr, Part::Indicator | ObjState::PRESSED);
         slider.set_value(70);
         slider.center();
 

--- a/examples/style16.rs
+++ b/examples/style16.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(target_arch = "xtensa", no_std, no_main)]
-#![cfg_attr(target_arch = "xtensa", feature(impl_trait_in_assoc_type, type_alias_impl_trait))]
+#![cfg_attr(
+    target_arch = "xtensa",
+    feature(impl_trait_in_assoc_type, type_alias_impl_trait)
+)]
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //! Style 16 — Conical gradient (metallic knob)
 
@@ -8,7 +11,10 @@ extern crate alloc;
 use alloc::boxed::Box;
 use oxivgl::{
     view::View,
-    widgets::{GradDsc, GradExtend, Obj, Screen, Style, WidgetError, color_black, color_make, lv_pct},
+    widgets::{
+        color_black, color_make, lv_pct, GradDsc, GradExtend, Obj, Screen, Selector, Style,
+        WidgetError,
+    },
 };
 
 struct Style16 {
@@ -33,8 +39,13 @@ impl View for Style16 {
         ];
 
         let mut grad = Box::new(GradDsc::new());
-        grad.init_stops(&colors, &[], &[])
-            .conical(lv_pct(50), lv_pct(50), 0, 120, GradExtend::Reflect);
+        grad.init_stops(&colors, &[], &[]).conical(
+            lv_pct(50),
+            lv_pct(50),
+            0,
+            120,
+            GradExtend::Reflect,
+        );
 
         let mut style = Box::new(Style::new());
         style
@@ -48,7 +59,7 @@ impl View for Style16 {
             .bg_grad(&grad);
 
         let obj = Obj::new(&screen)?;
-        obj.add_style(&style, 0);
+        obj.add_style(&style, Selector::DEFAULT);
         obj.size(200, 200);
         obj.center();
 

--- a/examples/style17.rs
+++ b/examples/style17.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(target_arch = "xtensa", no_std, no_main)]
-#![cfg_attr(target_arch = "xtensa", feature(impl_trait_in_assoc_type, type_alias_impl_trait))]
+#![cfg_attr(
+    target_arch = "xtensa",
+    feature(impl_trait_in_assoc_type, type_alias_impl_trait)
+)]
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //! Style 17 — Radial gradient
 
@@ -8,7 +11,7 @@ extern crate alloc;
 use alloc::boxed::Box;
 use oxivgl::{
     view::View,
-    widgets::{GradDsc, GradExtend, Obj, Screen, Style, WidgetError, color_make, lv_pct},
+    widgets::{color_make, lv_pct, GradDsc, GradExtend, Obj, Screen, Selector, Style, WidgetError},
 };
 
 struct Style17 {
@@ -21,20 +24,22 @@ impl View for Style17 {
     fn create() -> Result<Self, WidgetError> {
         let screen = Screen::active().ok_or(WidgetError::LvglNullPointer)?;
 
-        let colors = [
-            color_make(0x9b, 0x18, 0x42),
-            color_make(0x00, 0x00, 0x00),
-        ];
+        let colors = [color_make(0x9b, 0x18, 0x42), color_make(0x00, 0x00, 0x00)];
 
         let mut grad = Box::new(GradDsc::new());
-        grad.init_stops(&colors, &[], &[])
-            .radial(lv_pct(50), lv_pct(50), lv_pct(100), lv_pct(100), GradExtend::Pad);
+        grad.init_stops(&colors, &[], &[]).radial(
+            lv_pct(50),
+            lv_pct(50),
+            lv_pct(100),
+            lv_pct(100),
+            GradExtend::Pad,
+        );
 
         let mut style = Box::new(Style::new());
         style.bg_grad(&grad);
 
         let obj = Obj::new(&screen)?;
-        obj.add_style(&style, 0);
+        obj.add_style(&style, Selector::DEFAULT);
         obj.size(320, 240);
         obj.center();
 

--- a/examples/style18.rs
+++ b/examples/style18.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(target_arch = "xtensa", no_std, no_main)]
-#![cfg_attr(target_arch = "xtensa", feature(impl_trait_in_assoc_type, type_alias_impl_trait))]
+#![cfg_attr(
+    target_arch = "xtensa",
+    feature(impl_trait_in_assoc_type, type_alias_impl_trait)
+)]
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //! Style 18 — Various gradient buttons
 
@@ -9,8 +12,8 @@ use alloc::boxed::Box;
 use oxivgl::{
     view::View,
     widgets::{
-        Align, Button, GradDsc, GradDir, GradExtend, Label, Screen, Style, WidgetError, color_make,
-        lv_pct,
+        color_make, lv_pct, Align, Button, GradDir, GradDsc, GradExtend, Label, Screen, Selector,
+        Style, WidgetError,
     },
 };
 
@@ -38,44 +41,52 @@ impl View for Style18 {
         let colors = [c0, c1];
 
         let mut grad_linear = Box::new(GradDsc::new());
-        grad_linear
-            .init_stops(&colors, &[], &[])
-            .linear(lv_pct(0), lv_pct(0), lv_pct(20), lv_pct(100), GradExtend::Reflect);
+        grad_linear.init_stops(&colors, &[], &[]).linear(
+            lv_pct(0),
+            lv_pct(0),
+            lv_pct(20),
+            lv_pct(100),
+            GradExtend::Reflect,
+        );
         let mut style_linear = Box::new(Style::new());
         style_linear.bg_grad(&grad_linear).bg_opa(255);
 
         let mut grad_radial = Box::new(GradDsc::new());
-        grad_radial
-            .init_stops(&colors, &[], &[])
-            .radial(lv_pct(30), lv_pct(30), lv_pct(100), lv_pct(100), GradExtend::Reflect);
+        grad_radial.init_stops(&colors, &[], &[]).radial(
+            lv_pct(30),
+            lv_pct(30),
+            lv_pct(100),
+            lv_pct(100),
+            GradExtend::Reflect,
+        );
         let mut style_radial = Box::new(Style::new());
         style_radial.bg_grad(&grad_radial).bg_opa(255);
 
         let btn1 = Button::new(&screen)?;
         btn1.size(150, 50).align(Align::Center, 0, -100);
-        btn1.style_bg_color(c0, 0);
-        btn1.style_bg_grad_color(c1, 0);
-        btn1.style_bg_grad_dir(GradDir::Hor as u32, 0);
+        btn1.style_bg_color(c0, Selector::DEFAULT);
+        btn1.style_bg_grad_color(c1, Selector::DEFAULT);
+        btn1.style_bg_grad_dir(GradDir::Hor, Selector::DEFAULT);
         let label1 = Label::new(&btn1)?;
         label1.text("Horizontal").center();
 
         let btn2 = Button::new(&screen)?;
         btn2.size(150, 50).align(Align::Center, 0, -40);
-        btn2.style_bg_color(c0, 0);
-        btn2.style_bg_grad_color(c1, 0);
-        btn2.style_bg_grad_dir(GradDir::Ver as u32, 0);
+        btn2.style_bg_color(c0, Selector::DEFAULT);
+        btn2.style_bg_grad_color(c1, Selector::DEFAULT);
+        btn2.style_bg_grad_dir(GradDir::Ver, Selector::DEFAULT);
         let label2 = Label::new(&btn2)?;
         label2.text("Vertical").center();
 
         let btn3 = Button::new(&screen)?;
         btn3.size(150, 50).align(Align::Center, 0, 20);
-        btn3.add_style(&style_linear, 0);
+        btn3.add_style(&style_linear, Selector::DEFAULT);
         let label3 = Label::new(&btn3)?;
         label3.text("Linear").center();
 
         let btn4 = Button::new(&screen)?;
         btn4.size(150, 50).align(Align::Center, 0, 80);
-        btn4.add_style(&style_radial, 0);
+        btn4.add_style(&style_radial, Selector::DEFAULT);
         let label4 = Label::new(&btn4)?;
         label4.text("Radial").center();
 

--- a/examples/style2.rs
+++ b/examples/style2.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(target_arch = "xtensa", no_std, no_main)]
-#![cfg_attr(target_arch = "xtensa", feature(impl_trait_in_assoc_type, type_alias_impl_trait))]
+#![cfg_attr(
+    target_arch = "xtensa",
+    feature(impl_trait_in_assoc_type, type_alias_impl_trait)
+)]
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //! Style 2 — Background gradient
 
@@ -9,7 +12,8 @@ use alloc::boxed::Box;
 use oxivgl::{
     view::View,
     widgets::{
-        GradDsc, GradDir, Obj, Palette, Screen, Style, WidgetError, palette_lighten, palette_main,
+        palette_lighten, palette_main, GradDir, GradDsc, Obj, Palette, Screen, Selector, Style,
+        WidgetError,
     },
 };
 
@@ -33,7 +37,7 @@ impl View for Style2 {
         style.radius(5).bg_opa(255).bg_grad(&grad);
 
         let obj = Obj::new(&screen)?;
-        obj.add_style(&style, 0);
+        obj.add_style(&style, Selector::DEFAULT);
         obj.center();
 
         Ok(Self {

--- a/examples/style3.rs
+++ b/examples/style3.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(target_arch = "xtensa", no_std, no_main)]
-#![cfg_attr(target_arch = "xtensa", feature(impl_trait_in_assoc_type, type_alias_impl_trait))]
+#![cfg_attr(
+    target_arch = "xtensa",
+    feature(impl_trait_in_assoc_type, type_alias_impl_trait)
+)]
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //! Style 3 — Border
 
@@ -9,7 +12,8 @@ use alloc::boxed::Box;
 use oxivgl::{
     view::View,
     widgets::{
-        BorderSide, Obj, Palette, Screen, Style, WidgetError, palette_lighten, palette_main,
+        palette_lighten, palette_main, BorderSide, Obj, Palette, Screen, Selector, Style,
+        WidgetError,
     },
 };
 
@@ -33,7 +37,7 @@ impl View for Style3 {
             .border_side(BorderSide::BOTTOM | BorderSide::RIGHT);
 
         let obj = Obj::new(&screen)?;
-        obj.add_style(&style, 0);
+        obj.add_style(&style, Selector::DEFAULT);
         obj.center();
 
         Ok(Self {

--- a/examples/style4.rs
+++ b/examples/style4.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(target_arch = "xtensa", no_std, no_main)]
-#![cfg_attr(target_arch = "xtensa", feature(impl_trait_in_assoc_type, type_alias_impl_trait))]
+#![cfg_attr(
+    target_arch = "xtensa",
+    feature(impl_trait_in_assoc_type, type_alias_impl_trait)
+)]
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //! Style 4 — Outline
 
@@ -8,7 +11,7 @@ extern crate alloc;
 use alloc::boxed::Box;
 use oxivgl::{
     view::View,
-    widgets::{Obj, Palette, Screen, Style, WidgetError, palette_lighten, palette_main},
+    widgets::{palette_lighten, palette_main, Obj, Palette, Screen, Selector, Style, WidgetError},
 };
 
 struct Style4 {
@@ -30,7 +33,7 @@ impl View for Style4 {
             .outline_pad(8);
 
         let obj = Obj::new(&screen)?;
-        obj.add_style(&style, 0);
+        obj.add_style(&style, Selector::DEFAULT);
         obj.center();
 
         Ok(Self {

--- a/examples/style5.rs
+++ b/examples/style5.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(target_arch = "xtensa", no_std, no_main)]
-#![cfg_attr(target_arch = "xtensa", feature(impl_trait_in_assoc_type, type_alias_impl_trait))]
+#![cfg_attr(
+    target_arch = "xtensa",
+    feature(impl_trait_in_assoc_type, type_alias_impl_trait)
+)]
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //! Style 5 — Shadow
 
@@ -8,7 +11,7 @@ extern crate alloc;
 use alloc::boxed::Box;
 use oxivgl::{
     view::View,
-    widgets::{Obj, Palette, Screen, Style, WidgetError, palette_lighten, palette_main},
+    widgets::{palette_lighten, palette_main, Obj, Palette, Screen, Selector, Style, WidgetError},
 };
 
 struct Style5 {
@@ -29,7 +32,7 @@ impl View for Style5 {
             .shadow_color(palette_main(Palette::Blue));
 
         let obj = Obj::new(&screen)?;
-        obj.add_style(&style, 0);
+        obj.add_style(&style, Selector::DEFAULT);
         obj.center();
 
         Ok(Self {

--- a/examples/style7.rs
+++ b/examples/style7.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(target_arch = "xtensa", no_std, no_main)]
-#![cfg_attr(target_arch = "xtensa", feature(impl_trait_in_assoc_type, type_alias_impl_trait))]
+#![cfg_attr(
+    target_arch = "xtensa",
+    feature(impl_trait_in_assoc_type, type_alias_impl_trait)
+)]
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //! Style 7 — Arc color and width
 
@@ -8,7 +11,7 @@ extern crate alloc;
 use alloc::boxed::Box;
 use oxivgl::{
     view::View,
-    widgets::{Arc, Palette, Screen, Style, WidgetError, palette_main},
+    widgets::{palette_main, Arc, Palette, Screen, Selector, Style, WidgetError},
 };
 
 struct Style7 {
@@ -21,12 +24,10 @@ impl View for Style7 {
         let screen = Screen::active().ok_or(WidgetError::LvglNullPointer)?;
 
         let mut style = Box::new(Style::new());
-        style
-            .arc_color(palette_main(Palette::Red))
-            .arc_width(4);
+        style.arc_color(palette_main(Palette::Red)).arc_width(4);
 
         let arc = Arc::new(&screen)?;
-        arc.add_style(&style, 0);
+        arc.add_style(&style, Selector::DEFAULT);
         arc.center();
 
         Ok(Self {

--- a/examples/style8.rs
+++ b/examples/style8.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(target_arch = "xtensa", no_std, no_main)]
-#![cfg_attr(target_arch = "xtensa", feature(impl_trait_in_assoc_type, type_alias_impl_trait))]
+#![cfg_attr(
+    target_arch = "xtensa",
+    feature(impl_trait_in_assoc_type, type_alias_impl_trait)
+)]
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //! Style 8 — Text styles
 
@@ -8,7 +11,10 @@ extern crate alloc;
 use alloc::boxed::Box;
 use oxivgl::{
     view::View,
-    widgets::{Label, Palette, Screen, Style, TextDecor, WidgetError, palette_lighten, palette_main},
+    widgets::{
+        palette_lighten, palette_main, Label, Palette, Screen, Selector, Style, TextDecor,
+        WidgetError,
+    },
 };
 
 struct Style8 {
@@ -34,7 +40,7 @@ impl View for Style8 {
             .text_decor(TextDecor::UNDERLINE);
 
         let label = Label::new(&screen)?;
-        label.add_style(&style, 0);
+        label.add_style(&style, Selector::DEFAULT);
         label.text("Text of\na label");
         label.center();
 

--- a/examples/style9.rs
+++ b/examples/style9.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(target_arch = "xtensa", no_std, no_main)]
-#![cfg_attr(target_arch = "xtensa", feature(impl_trait_in_assoc_type, type_alias_impl_trait))]
+#![cfg_attr(
+    target_arch = "xtensa",
+    feature(impl_trait_in_assoc_type, type_alias_impl_trait)
+)]
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //! Style 9 — Line styles
 
@@ -8,7 +11,9 @@ extern crate alloc;
 use alloc::boxed::Box;
 use oxivgl::{
     view::View,
-    widgets::{Line, Palette, Screen, Style, WidgetError, lv_point_precise_t, palette_main},
+    widgets::{
+        lv_point_precise_t, palette_main, Line, Palette, Screen, Selector, Style, WidgetError,
+    },
 };
 
 struct Style9 {
@@ -34,7 +39,7 @@ impl View for Style9 {
         ]);
 
         let line = Line::new(&screen)?;
-        line.add_style(&style, 0);
+        line.add_style(&style, Selector::DEFAULT);
         line.set_points(&*points);
         line.center();
 

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -24,7 +24,8 @@ impl Font {
     /// importing `lvgl_rust_sys` directly:
     ///
     /// ```no_run
-    /// extern "C" { static my_font: u8; }
+    /// use oxivgl::fonts::Font;
+    /// unsafe extern "C" { static my_font: u8; }
     /// static MY_FONT: Font = unsafe {
     ///     Font::from_extern(core::ptr::addr_of!(my_font) as *const ())
     /// };

--- a/src/widgets/event.rs
+++ b/src/widgets/event.rs
@@ -61,7 +61,8 @@ impl Event {
 
     /// Set a style property on the event target. Convenience for event handlers
     /// that need to modify the originating widget (e.g. event bubbling).
-    pub fn target_style_bg_color(&self, color: lv_color_t, selector: u32) {
+    pub fn target_style_bg_color(&self, color: lv_color_t, selector: impl Into<super::Selector>) {
+        let selector = selector.into().raw();
         // SAFETY: target_handle() returns a valid LVGL object for callback duration.
         unsafe { lv_obj_set_style_bg_color(self.target_handle(), color, selector) };
     }

--- a/src/widgets/grid.rs
+++ b/src/widgets/grid.rs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Grid cell placement helper.
+
+/// Grid cell placement (alignment + position + span).
+/// Used with [`Obj::set_grid_cell`](super::Obj::set_grid_cell) to avoid
+/// positional argument confusion.
+///
+/// ```ignore
+/// use oxivgl::widgets::{GridAlign, GridCell};
+/// obj.set_grid_cell(
+///     GridCell::new(GridAlign::Stretch, 0, 1),
+///     GridCell::new(GridAlign::Center, 0, 1),
+/// );
+/// ```
+#[derive(Clone, Copy, Debug)]
+pub struct GridCell {
+    pub align: super::obj::GridAlign,
+    pub pos: i32,
+    pub span: i32,
+}
+
+impl GridCell {
+    /// Create a grid cell placement.
+    pub fn new(align: super::obj::GridAlign, pos: i32, span: i32) -> Self {
+        Self { align, pos, span }
+    }
+
+    /// Single-cell at given position with Start alignment and span 1.
+    pub fn at(pos: i32) -> Self {
+        Self {
+            align: super::obj::GridAlign::Start,
+            pos,
+            span: 1,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::widgets::obj::GridAlign;
+
+    #[test]
+    fn at_defaults_to_start_span1() {
+        let c = GridCell::at(2);
+        assert_eq!(c.pos, 2);
+        assert_eq!(c.span, 1);
+        // GridAlign doesn't impl PartialEq, so check via debug
+        assert!(format!("{:?}", c.align).contains("Start"));
+    }
+
+    #[test]
+    fn new_preserves_fields() {
+        let c = GridCell::new(GridAlign::Center, 3, 2);
+        assert_eq!(c.pos, 3);
+        assert_eq!(c.span, 2);
+    }
+}

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -23,6 +23,7 @@ mod child;
 mod enums;
 pub(crate) mod event;
 mod grad;
+mod grid;
 mod image;
 mod label;
 mod led;
@@ -34,6 +35,7 @@ mod palette;
 pub mod prelude;
 mod scale;
 mod screen;
+mod selector;
 mod slider;
 mod style;
 mod switch;
@@ -52,6 +54,7 @@ pub use child::{detach, Child};
 pub use enums::{EventCode, Layout, ObjFlag, ObjState, Opa, ScrollbarMode};
 pub use event::Event;
 pub use grad::{GradDsc, GradExtend};
+pub use grid::GridCell;
 pub use image::Image;
 pub use label::Label;
 pub use led::Led;
@@ -61,8 +64,9 @@ pub use palette::{
     color_black, color_make, color_white, palette_darken, palette_lighten, palette_main, GradDir,
     Palette,
 };
-pub use scale::{Scale, ScaleMode};
+pub use scale::{Scale, ScaleBuilder, ScaleMode};
 pub use screen::Screen;
+pub use selector::Selector;
 pub use slider::Slider;
 pub use style::{
     darken_filter_cb, lv_pct, props, BorderSide, ColorFilter, Style, TextDecor, TransitionDsc,
@@ -75,6 +79,10 @@ pub use value_label::ValueLabel;
 pub use lvgl_rust_sys::{lv_color_t, lv_event_t, lv_point_precise_t};
 
 // Grid helpers
+/// Maximum corner radius — creates a pill/capsule shape.
+/// Equivalent to LVGL's `LV_RADIUS_CIRCLE` (0x7FFF).
+pub const RADIUS_MAX: i32 = 0x7FFF;
+
 /// Sentinel value marking the end of a grid template descriptor array.
 pub const GRID_TEMPLATE_LAST: i32 = lvgl_rust_sys::LV_COORD_MAX as i32;
 

--- a/src/widgets/obj_layout.rs
+++ b/src/widgets/obj_layout.rs
@@ -53,26 +53,18 @@ impl<'p> Obj<'p> {
         self
     }
 
-    pub fn set_grid_cell(
-        &self,
-        col_align: GridAlign,
-        col: i32,
-        col_span: i32,
-        row_align: GridAlign,
-        row: i32,
-        row_span: i32,
-    ) -> &Self {
+    pub fn set_grid_cell(&self, col: super::grid::GridCell, row: super::grid::GridCell) -> &Self {
         assert_ne!(self.handle(), null_mut());
         // SAFETY: handle non-null (asserted above).
         unsafe {
             lv_obj_set_grid_cell(
                 self.handle(),
-                col_align as lv_grid_align_t,
-                col,
-                col_span,
-                row_align as lv_grid_align_t,
-                row,
-                row_span,
+                col.align as lv_grid_align_t,
+                col.pos,
+                col.span,
+                row.align as lv_grid_align_t,
+                row.pos,
+                row.span,
             )
         };
         self

--- a/src/widgets/obj_style.rs
+++ b/src/widgets/obj_style.rs
@@ -66,10 +66,16 @@ impl<'p> Obj<'p> {
     }
 
     /// Apply a style to this object for the given selector.
-    /// Pass `0` for default state, `ObjState::PRESSED.0` for pressed.
     ///
     /// The `style` must outlive this object (see [`Style`](super::Style) docs).
-    pub fn add_style(&self, style: &super::Style, selector: u32) -> &Self {
+    ///
+    /// ```ignore
+    /// btn.add_style(&style, Selector::DEFAULT);
+    /// btn.add_style(&style, ObjState::PRESSED);
+    /// slider.add_style(&style, Part::Indicator | ObjState::PRESSED);
+    /// ```
+    pub fn add_style(&self, style: &super::Style, selector: impl Into<super::Selector>) -> &Self {
+        let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
         // SAFETY: handle non-null; style.inner pointer valid for style's lifetime.
         unsafe { lv_obj_add_style(self.handle(), &style.inner as *const lv_style_t, selector) };
@@ -118,9 +124,10 @@ impl<'p> Obj<'p> {
         self
     }
 
-    /// Set the corner radius for the given style selector (0 = default state).
-    /// Use `0x7fff` for a pill/capsule shape.
-    pub fn radius(&self, r: i32, selector: u32) -> &Self {
+    /// Set the corner radius for the given style selector.
+    /// Use [`RADIUS_MAX`](super::RADIUS_MAX) for a pill/capsule shape.
+    pub fn radius(&self, r: i32, selector: impl Into<super::Selector>) -> &Self {
+        let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
         // SAFETY: handle non-null (asserted above).
         unsafe { lv_obj_set_style_radius(self.handle(), r, selector) };
@@ -128,7 +135,8 @@ impl<'p> Obj<'p> {
     }
 
     /// Set local `bg_color` style for the given selector (part | state).
-    pub fn style_bg_color(&self, color: lv_color_t, selector: u32) -> &Self {
+    pub fn style_bg_color(&self, color: lv_color_t, selector: impl Into<super::Selector>) -> &Self {
+        let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
         // SAFETY: handle non-null (asserted above).
         unsafe { lv_obj_set_style_bg_color(self.handle(), color, selector) };
@@ -136,7 +144,12 @@ impl<'p> Obj<'p> {
     }
 
     /// Set local `bg_grad_color` for the given selector.
-    pub fn style_bg_grad_color(&self, color: lv_color_t, selector: u32) -> &Self {
+    pub fn style_bg_grad_color(
+        &self,
+        color: lv_color_t,
+        selector: impl Into<super::Selector>,
+    ) -> &Self {
+        let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
         // SAFETY: handle non-null (asserted above).
         unsafe { lv_obj_set_style_bg_grad_color(self.handle(), color, selector) };
@@ -144,7 +157,12 @@ impl<'p> Obj<'p> {
     }
 
     /// Set local `bg_grad_dir` for the given selector.
-    pub fn style_bg_grad_dir(&self, dir: u32, selector: u32) -> &Self {
+    pub fn style_bg_grad_dir(
+        &self,
+        dir: super::palette::GradDir,
+        selector: impl Into<super::Selector>,
+    ) -> &Self {
+        let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
         // SAFETY: handle non-null (asserted above).
         unsafe { lv_obj_set_style_bg_grad_dir(self.handle(), dir as lv_grad_dir_t, selector) };
@@ -152,7 +170,12 @@ impl<'p> Obj<'p> {
     }
 
     /// Set transform rotation in 0.1 degree units for the given selector.
-    pub fn style_transform_rotation(&self, angle: i32, selector: u32) -> &Self {
+    pub fn style_transform_rotation(
+        &self,
+        angle: i32,
+        selector: impl Into<super::Selector>,
+    ) -> &Self {
+        let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
         // SAFETY: handle non-null (asserted above).
         unsafe { lv_obj_set_style_transform_rotation(self.handle(), angle, selector) };
@@ -160,7 +183,8 @@ impl<'p> Obj<'p> {
     }
 
     /// Set uniform transform scale (256 = 1.0x) for the given selector.
-    pub fn style_transform_scale(&self, scale: i32, selector: u32) -> &Self {
+    pub fn style_transform_scale(&self, scale: i32, selector: impl Into<super::Selector>) -> &Self {
+        let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
         // SAFETY: handle non-null (asserted above).
         unsafe {
@@ -171,7 +195,8 @@ impl<'p> Obj<'p> {
     }
 
     /// Set transform pivot X for the given selector.
-    pub fn style_transform_pivot_x(&self, x: i32, selector: u32) -> &Self {
+    pub fn style_transform_pivot_x(&self, x: i32, selector: impl Into<super::Selector>) -> &Self {
+        let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
         // SAFETY: handle non-null (asserted above).
         unsafe { lv_obj_set_style_transform_pivot_x(self.handle(), x, selector) };
@@ -179,14 +204,20 @@ impl<'p> Obj<'p> {
     }
 
     /// Set transform pivot Y for the given selector.
-    pub fn style_transform_pivot_y(&self, y: i32, selector: u32) -> &Self {
+    pub fn style_transform_pivot_y(&self, y: i32, selector: impl Into<super::Selector>) -> &Self {
+        let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
         // SAFETY: handle non-null (asserted above).
         unsafe { lv_obj_set_style_transform_pivot_y(self.handle(), y, selector) };
         self
     }
 
-    pub fn set_style_base_dir(&self, dir: super::obj::BaseDir, selector: u32) -> &Self {
+    pub fn set_style_base_dir(
+        &self,
+        dir: super::obj::BaseDir,
+        selector: impl Into<super::Selector>,
+    ) -> &Self {
+        let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut());
         // SAFETY: handle non-null (asserted above).
         unsafe { lv_obj_set_style_base_dir(self.handle(), dir as lv_base_dir_t, selector) };

--- a/src/widgets/prelude.rs
+++ b/src/widgets/prelude.rs
@@ -6,6 +6,7 @@
 //! ```
 
 pub use super::{
-    Align, AsLvHandle, Button, Event, EventCode, FlexAlign, FlexFlow, GridAlign, Label, Layout,
-    Obj, ObjFlag, ObjState, Opa, Palette, Screen, Slider, Style, Switch, WidgetError,
+    Align, AsLvHandle, Button, Event, EventCode, FlexAlign, FlexFlow, GridAlign, GridCell, Label,
+    Layout, Obj, ObjFlag, ObjState, Opa, Palette, Screen, Selector, Slider, Style, Switch,
+    WidgetError, RADIUS_MAX,
 };

--- a/src/widgets/scale.rs
+++ b/src/widgets/scale.rs
@@ -125,3 +125,109 @@ impl<'p> Scale<'p> {
         Ok(scale)
     }
 }
+
+/// Builder for [`Scale::tick_ring`] — avoids 13 positional arguments.
+///
+/// ```ignore
+/// let scale = ScaleBuilder::new(200, ScaleMode::RoundOuter)
+///     .rotation(135)
+///     .sweep(270)
+///     .range_max(100)
+///     .total_ticks(21)
+///     .major_every(5)
+///     .build(&screen)?;
+/// ```
+pub struct ScaleBuilder {
+    size: i32,
+    mode: ScaleMode,
+    rotation: i32,
+    sweep: i32,
+    range_max: i32,
+    total_ticks: u32,
+    major_every: u32,
+    show_labels: bool,
+    major_len: i32,
+    minor_len: i32,
+    major_color: u32,
+    minor_color: u32,
+}
+
+impl ScaleBuilder {
+    /// Start with required fields (size, mode), sensible defaults for the rest.
+    pub fn new(size: i32, mode: ScaleMode) -> Self {
+        Self {
+            size,
+            mode,
+            rotation: 0,
+            sweep: 360,
+            range_max: 100,
+            total_ticks: 11,
+            major_every: 5,
+            show_labels: true,
+            major_len: 10,
+            minor_len: 5,
+            major_color: 0x000000,
+            minor_color: 0x808080,
+        }
+    }
+
+    pub fn rotation(mut self, v: i32) -> Self {
+        self.rotation = v;
+        self
+    }
+    pub fn sweep(mut self, v: i32) -> Self {
+        self.sweep = v;
+        self
+    }
+    pub fn range_max(mut self, v: i32) -> Self {
+        self.range_max = v;
+        self
+    }
+    pub fn total_ticks(mut self, v: u32) -> Self {
+        self.total_ticks = v;
+        self
+    }
+    pub fn major_every(mut self, v: u32) -> Self {
+        self.major_every = v;
+        self
+    }
+    pub fn show_labels(mut self, v: bool) -> Self {
+        self.show_labels = v;
+        self
+    }
+    pub fn major_len(mut self, v: i32) -> Self {
+        self.major_len = v;
+        self
+    }
+    pub fn minor_len(mut self, v: i32) -> Self {
+        self.minor_len = v;
+        self
+    }
+    pub fn major_color(mut self, v: u32) -> Self {
+        self.major_color = v;
+        self
+    }
+    pub fn minor_color(mut self, v: u32) -> Self {
+        self.minor_color = v;
+        self
+    }
+
+    /// Build the scale widget.
+    pub fn build(self, parent: &impl AsLvHandle) -> Result<Scale<'_>, WidgetError> {
+        Scale::tick_ring(
+            parent,
+            self.size,
+            self.mode,
+            self.rotation,
+            self.sweep,
+            self.range_max,
+            self.total_ticks,
+            self.major_every,
+            self.show_labels,
+            self.major_len,
+            self.minor_len,
+            self.major_color,
+            self.minor_color,
+        )
+    }
+}

--- a/src/widgets/selector.rs
+++ b/src/widgets/selector.rs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Type-safe style selector combining [`Part`](super::obj::Part) and
+//! [`ObjState`](super::ObjState) bits.
+//!
+//! Replaces raw `u32` in all style-related methods.
+//!
+//! ```ignore
+//! use oxivgl::widgets::{ObjState, Selector};
+//! use oxivgl::widgets::obj::Part;
+//!
+//! btn.add_style(&style, Selector::DEFAULT);
+//! btn.add_style(&style, ObjState::PRESSED);
+//! slider.add_style(&style, Part::Indicator | ObjState::PRESSED);
+//! ```
+
+/// Style selector = [`Part`](super::obj::Part) + [`ObjState`](super::ObjState)
+/// bits. Pass to methods like [`Obj::add_style`](super::Obj::add_style),
+/// [`Obj::radius`](super::Obj::radius), etc.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Selector(u32);
+
+impl Selector {
+    /// Default selector (main part, default state).
+    pub const DEFAULT: Self = Self(0);
+
+    /// Raw `u32` value for passing to LVGL FFI.
+    pub fn raw(self) -> u32 {
+        self.0
+    }
+}
+
+impl From<super::obj::Part> for Selector {
+    fn from(p: super::obj::Part) -> Self {
+        Self(p as u32)
+    }
+}
+
+impl From<super::ObjState> for Selector {
+    fn from(s: super::ObjState) -> Self {
+        Self(s.0)
+    }
+}
+
+impl core::ops::BitOr<super::ObjState> for super::obj::Part {
+    type Output = Selector;
+    fn bitor(self, rhs: super::ObjState) -> Selector {
+        Selector(self as u32 | rhs.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::widgets::obj::Part;
+    use crate::widgets::ObjState;
+
+    #[test]
+    fn default_is_zero() {
+        assert_eq!(Selector::DEFAULT.raw(), 0);
+        assert_eq!(Selector::default().raw(), 0);
+    }
+
+    #[test]
+    fn from_part() {
+        let s: Selector = Part::Indicator.into();
+        assert_eq!(s.raw(), Part::Indicator as u32);
+    }
+
+    #[test]
+    fn from_state() {
+        let s: Selector = ObjState::PRESSED.into();
+        assert_eq!(s.raw(), ObjState::PRESSED.0);
+    }
+
+    #[test]
+    fn part_bitor_state() {
+        let s = Part::Indicator | ObjState::PRESSED;
+        assert_eq!(s.raw(), Part::Indicator as u32 | ObjState::PRESSED.0);
+    }
+}


### PR DESCRIPTION
## Summary
- **Selector type**: Replace raw `u32` in all style methods with `impl Into<Selector>` — accepts `Part`, `ObjState`, or `Part | ObjState`
- **GridCell struct**: Replace 6 positional args in `set_grid_cell` with 2 `GridCell` args (col, row)
- **ScaleBuilder**: Builder pattern for the 13-param `tick_ring` constructor
- **RADIUS_MAX**: Named constant replacing magic `0x7fff` across examples
- **GradDir type safety**: `style_bg_grad_dir` takes enum instead of `u32`
- **Prelude updated**: Includes all new types (Selector, GridCell, RADIUS_MAX)
- Fix fonts.rs doctest for Rust 2024 `unsafe extern` syntax

## Test plan
- [x] All 14 unit tests pass
- [x] All 8 doctests pass (including fixed fonts.rs)
- [x] Host build check passes
- [x] ESP32 flash + run verified (style7 on Fire27)

🤖 Generated with [Claude Code](https://claude.com/claude-code)