### PR TITLE
feat: SDL2 window display for interactive host examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,12 +24,14 @@ LIBCLANG_PATH=/usr/lib64 cargo +nightly test --target x86_64-unknown-linux-gnu t
 # Audit doc coverage (should report 0 missing):
 LIBCLANG_PATH=/usr/lib64 RUSTDOCFLAGS="-W missing-docs" cargo +nightly doc --target x86_64-unknown-linux-gnu --no-deps 2>&1 | grep "warning:"
 
-# Run host example:
+# Run host example (interactive SDL window):
 ./run_host.sh getting_started1
-./run_host.sh style16
+
+# Capture screenshot (headless, no window):
+./run_host.sh -s getting_started1
 
 # Capture all screenshots:
-./run_screenshots.sh
+./run_host.sh -s
 
 # Flash ESP32 example (requires Xtensa toolchain + connected board):
 ./run_fire27.sh getting_started1

--- a/examples/common/src/host.rs
+++ b/examples/common/src/host.rs
@@ -101,7 +101,13 @@ macro_rules! host_main {
             use $crate::oxivgl::view::View;
 
             $crate::env_logger::init();
-            let _driver = LvglDriver::init(W, H);
+            let screenshot_only =
+                std::env::var("SCREENSHOT_ONLY").as_deref() == Ok("1");
+            let _driver = if screenshot_only {
+                LvglDriver::init(W, H)
+            } else {
+                LvglDriver::init_sdl(W, H)
+            };
             let mut _view = <$View>::create().expect("view create failed");
             $crate::oxivgl::view::register_view_events(&mut _view);
 
@@ -121,7 +127,7 @@ macro_rules! host_main {
             pump(10);
             capture(name, &dir);
 
-            if std::env::var("SCREENSHOT_ONLY").as_deref() == Ok("1") {
+            if screenshot_only {
                 // Skip Rust destructors — LVGL's internal state (timers,
                 // display refresh) can race with lv_obj_delete during
                 // Drop, causing intermittent SIGSEGV on exit.

--- a/run_host.sh
+++ b/run_host.sh
@@ -1,5 +1,65 @@
 #!/usr/bin/env bash
-# Run an LVGL example on the host via SDL2.
-# Usage: ./run_host.sh <example_name>
+# Run LVGL examples on the host via SDL2.
+#
+# Usage:
+#   ./run_host.sh <example>           Interactive SDL window
+#   ./run_host.sh -s <example>        Screenshot only (no window)
+#   ./run_host.sh -s                  Screenshot all examples
 set -e
-LIBCLANG_PATH=/usr/lib64 cargo +nightly run --example "${1:?usage: $0 <example>}" --target x86_64-unknown-linux-gnu
+
+export LIBCLANG_PATH=/usr/lib64
+TARGET="x86_64-unknown-linux-gnu"
+
+SCREENSHOT=0
+if [[ "${1:-}" == "-s" ]]; then
+    SCREENSHOT=1
+    shift
+fi
+
+ALL_EXAMPLES=(
+    getting_started{1,2,3,4,5,6,7,8}
+    style{1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18}
+    anim{1,2} anim_timeline1
+    event_{click,button,bubble,trickle}
+    flex{1,2,3,4,5,6}
+    grid{1,2,3,4,5,6}
+    scroll{1,2,4}
+    widget_obj{1,3}
+    widget_arc{1,2}
+    image1
+    widget_bar{1,2,3,4,5}
+    widget_button{1,2}
+    widget_checkbox1
+    widget_dropdown{1,2}
+    widget_label{1,2}
+    widget_led1
+    widget_roller1
+    widget_slider2
+)
+
+run_example() {
+    local ex="$1"
+    if [[ "$SCREENSHOT" == 1 ]]; then
+        echo "=== $ex ==="
+        SCREENSHOT_ONLY=1 SDL_VIDEODRIVER=dummy \
+            cargo +nightly run --example "$ex" --target "$TARGET"
+    else
+        echo "Running $ex (SDL window)… Close the window or press Ctrl-C to exit."
+        cargo +nightly run --example "$ex" --target "$TARGET"
+    fi
+}
+
+if [[ $# -eq 0 && "$SCREENSHOT" == 1 ]]; then
+    # Screenshot all examples
+    for ex in "${ALL_EXAMPLES[@]}"; do
+        run_example "$ex"
+    done
+elif [[ $# -ge 1 ]]; then
+    run_example "$1"
+else
+    echo "Usage: $0 [-s] [<example>]"
+    echo "  $0 <example>       Interactive SDL window"
+    echo "  $0 -s <example>    Screenshot only (no window)"
+    echo "  $0 -s              Screenshot all examples"
+    exit 1
+fi

--- a/run_screenshots.sh
+++ b/run_screenshots.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 # Capture screenshots for all examples.
+# Delegates to run_host.sh -s (headless, no SDL window).
 set -e
-for ex in getting_started{1,2,3,4,5,6,7,8} style{1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18} anim{1,2} anim_timeline1 event_{click,button,bubble,trickle} flex{1,2,3,4,5,6} grid{1,2,3,4,5,6} scroll{1,2,4} widget_obj{1,3} widget_arc{1,2} image1 widget_bar{1,2,3,4,5} widget_button{1,2} widget_checkbox1 widget_dropdown{1,2} widget_label{1,2} widget_led1 widget_roller1 widget_slider2; do
-  echo "=== $ex ==="
-  SCREENSHOT_ONLY=1 LIBCLANG_PATH=/usr/lib64 cargo +nightly run --example "$ex" --target x86_64-unknown-linux-gnu
-done
+exec ./run_host.sh -s

--- a/src/lvgl.rs
+++ b/src/lvgl.rs
@@ -10,6 +10,8 @@ impl LvglDriver {
     /// Initialise LVGL: calls `lv_init`, registers the log and tick callbacks,
     /// and (host-only) sets up a software display of `w × h` pixels.
     /// Must be called exactly once.
+    /// Initialise LVGL with a headless software display (for tests,
+    /// screenshots, and embedded targets).
     pub fn init(w: i32, h: i32) -> Self {
         // SAFETY: lv_init() is called exactly once (LvglDriver is non-Clone);
         // lvgl_log_print and get_tick_ms have the correct C callback signatures.
@@ -21,6 +23,19 @@ impl LvglDriver {
             init_host_display(w, h);
         }
         let _ = (w, h); // params unused on embedded target
+        Self
+    }
+
+    /// Initialise LVGL with an SDL2 window display (interactive host demos).
+    #[cfg(not(target_os = "none"))]
+    pub fn init_sdl(w: i32, h: i32) -> Self {
+        // SAFETY: same as init(); init_sdl_display creates an SDL2 window.
+        unsafe {
+            lv_init();
+            lv_log_register_print_cb(Some(lvgl_log_print));
+            lv_tick_set_cb(Some(get_tick_ms));
+            init_sdl_display(w, h);
+        }
         Self
     }
 }
@@ -36,6 +51,7 @@ unsafe extern "C" fn flush_cb(drv: *mut lv_display_t, _area: *const lv_area_t, _
     unsafe { lv_display_flush_ready(drv) };
 }
 
+/// Create a headless software display (for tests and screenshots).
 #[cfg(not(target_os = "none"))]
 unsafe fn init_host_display(w: i32, h: i32) {
     // Full-height buffer: rotated/scaled objects need sub-layers that can
@@ -62,6 +78,16 @@ unsafe fn init_host_display(w: i32, h: i32) {
     };
     // SAFETY: flush_cb is a valid extern "C" fn with the correct LVGL flush callback signature.
     unsafe { lv_display_set_flush_cb(disp, Some(flush_cb)) };
+}
+
+/// Create an SDL2 window display (for interactive host demos).
+/// Falls back to headless if `SDL_VIDEODRIVER=dummy`.
+#[cfg(not(target_os = "none"))]
+unsafe fn init_sdl_display(w: i32, h: i32) {
+    // SAFETY: lv_init() has been called; lv_sdl_window_create initialises
+    // SDL2 and creates a visible window with its own render loop.
+    let disp = unsafe { lv_sdl_window_create(w, h) };
+    assert!(!disp.is_null(), "lv_sdl_window_create returned NULL");
 }
 
 // ── Log callback ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Replaces PR #23 (which was accidentally merged into a feature branch instead of master).

- `LvglDriver::init_sdl()` — creates an SDL2 window for interactive host demos
- `./run_host.sh` script for running examples with live display
- `./run_host.sh -s` for headless screenshot capture

## Test plan

- [ ] `./run_host.sh getting_started1` opens SDL2 window
- [ ] `./run_host.sh -s` captures screenshots headlessly

🤖 Generated with [Claude Code](https://claude.com/claude-code)