### PR TITLE
ci: checkout v5, drop cargo-llvm-cov install, gate unused feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
             "https://github.com/emobotics-dev/oxivgl/"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -64,9 +64,6 @@ jobs:
         run: |
           SDL_VIDEODRIVER=dummy cargo +nightly test --test integration \
             --target x86_64-unknown-linux-gnu -- --test-threads=1
-
-      - name: Install cargo-llvm-cov
-        run: cargo +nightly install cargo-llvm-cov --locked
 
       - name: Measure coverage (unit + integration)
         id: coverage
@@ -119,7 +116,7 @@ jobs:
             "https://github.com/emobotics-dev/oxivgl/"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //! Safe Rust bindings for LVGL on embedded and host targets.
 #![cfg_attr(target_os = "none", no_std)]
-#![feature(type_alias_impl_trait)]
+#![cfg_attr(target_os = "none", feature(type_alias_impl_trait))]
 #![cfg_attr(target_os = "none", feature(asm_experimental_arch))]
 
 extern crate alloc;


### PR DESCRIPTION
## Summary

- `actions/checkout` v4 → v5 (Node.js 20 deprecated June 2026)
- Remove `cargo-llvm-cov` install step (now in CI container)
- Gate `type_alias_impl_trait` to `target_os = "none"` (silences host warning)

## Test plan

- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)