### PR TITLE
fix: pin espflash install to v4.3.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -38,7 +38,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
 
 # ── ESP/Xtensa toolchain (via espup) ────────────────────────────────
 RUN cargo install espup \
-    && cargo install --git https://github.com/esp-rs/espflash espflash \
+    && cargo install espflash@4.3.0 --locked \
     && espup install \
     && rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git"
 


### PR DESCRIPTION
## Summary
- Install `espflash` from crates.io with a pinned version (`4.3.0 --locked`) instead of building from git HEAD
- Ensures reproducible devcontainer builds

## Test plan
- [x] Build devcontainer image and verify `espflash --version` returns 4.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)