### PR TITLE
fix: docs.rs build for v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] — 2026-05-06
+
+### Fixed
+
+- docs.rs documentation build: `oxivgl-sys` now falls back to a bundled
+  `default-conf/lv_conf.h` under `DOCS_RS=1` (the workspace
+  `.cargo/config.toml` is unavailable on docs.rs), and `oxivgl/build.rs`
+  skips image asset compilation in the same environment.
+
 ## [0.1.0] — 2026-04-09
 
 Initial public release.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "oxivgl"
 edition = "2024"
-version = "0.1.0"
+version = "0.1.1"
 license = "MIT OR Apache-2.0"
 description = "Safe no_std Rust bindings for LVGL — embedded GUI on ESP32 and host SDL2"
 repository = "https://github.com/emobotics-dev/oxivgl"
@@ -38,7 +38,7 @@ log-04 = ["dep:log-04"]
 png = ["dep:png"]
 
 [dependencies]
-oxivgl_sys = { package = "oxivgl-sys", version = "0.1.0", path = "oxivgl-sys", default-features = false }
+oxivgl_sys = { package = "oxivgl-sys", version = "0.1.1", path = "oxivgl-sys", default-features = false }
 embassy-sync = "0.7.2"
 embassy-time = "0.5.0"
 heapless = { version = "0.9.1", features = ["nightly"] }
@@ -58,7 +58,7 @@ exclude = ["examples/common", "oxivgl-build", "oxivgl-sys"]
 
 [dev-dependencies]
 oxivgl-examples-common = { path = "examples/common" }
-oxivgl_sys = { package = "oxivgl-sys", version = "0.1.0", path = "oxivgl-sys", default-features = false }
+oxivgl_sys = { package = "oxivgl-sys", version = "0.1.1", path = "oxivgl-sys", default-features = false }
 
 # Proc-macro crates needed by fire27_main! attribute/macro expansion on xtensa
 [target.'cfg(target_arch = "xtensa")'.dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ oxivgl_sys = { package = "oxivgl-sys", version = "0.1.1", path = "oxivgl-sys", d
 [target.'cfg(target_arch = "xtensa")'.dev-dependencies]
 embassy-executor       = { version = "0.9.1", features = ["nightly"] }
 esp-bootloader-esp-idf = { version = "0.4.0", features = ["esp32"] }
-esp-hal                = { version = "1.0.0", features = ["esp32", "unstable"] }
+esp-hal                = { version = "=1.0.0", features = ["esp32", "unstable"] }
 esp-rtos               = { version = "0.2.0", features = ["esp32", "embassy"] }
 
 [profile.dev]

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 fn main() {
+    // docs.rs has no lv_conf.h and oxivgl-sys skips C compilation under DOCS_RS,
+    // so skip image asset generation here too — only Rust docs need to render.
+    if std::env::var("DOCS_RS").is_ok() {
+        return;
+    }
+
     let target = std::env::var("TARGET").unwrap_or_default();
     if target.starts_with("xtensa-") {
         println!("cargo:rustc-link-arg=-Tlinkall.x");

--- a/examples/common/Cargo.toml
+++ b/examples/common/Cargo.toml
@@ -20,7 +20,7 @@ oxivgl_sys = { package = "oxivgl-sys", path = "../../oxivgl-sys", default-featur
 esp-alloc            = { version = "0.9.0", features = ["internal-heap-stats"] }
 esp-backtrace        = { version = "0.18.1", features = ["esp32", "panic-handler", "custom-halt", "colors", "println"] }
 esp-bootloader-esp-idf = { version = "0.4.0", features = ["esp32"] }
-esp-hal              = { version = "1.0.0", features = ["esp32", "unstable"] }
+esp-hal              = { version = "=1.0.0", features = ["esp32", "unstable"] }
 esp-println          = { version = "0.16.1", features = ["esp32", "log-04", "colors", "uart"], default-features = false }
 esp-rtos             = { version = "0.2.0", features = ["esp32", "embassy"] }
 esp-sync             = { version = "0.1.1", features = ["esp32"] }

--- a/oxivgl-sys/Cargo.toml
+++ b/oxivgl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxivgl-sys"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Raw LVGL v9.5 FFI bindings for oxivgl — compiled from source with bindgen"
@@ -11,7 +11,7 @@ keywords = ["lvgl", "ffi", "embedded-gui", "esp32", "no-std"]
 categories = ["external-ffi-bindings", "no-std"]
 links = "lv"
 build = "build.rs"
-include = ["src/**", "shims/**", "build.rs", "Cargo.toml", "LICENSE-*"]
+include = ["src/**", "shims/**", "default-conf/**", "build.rs", "Cargo.toml", "LICENSE-*"]
 
 [features]
 default = ["use-string-functions"]

--- a/oxivgl-sys/build.rs
+++ b/oxivgl-sys/build.rs
@@ -77,17 +77,6 @@ impl bindgen::callbacks::ParseCallbacks for IgnoreMacros {
 }
 
 fn main() {
-    // docs.rs cannot compile LVGL — emit empty bindings and return
-    if env::var("DOCS_RS").is_ok() {
-        let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-        std::fs::write(
-            out_path.join("bindings.rs"),
-            "// empty bindings for docs.rs\n",
-        )
-        .unwrap();
-        return;
-    }
-
     let project_dir = canonicalize(PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()));
     let shims_dir = project_dir.join("shims");
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
@@ -134,14 +123,17 @@ fn main() {
     let drivers = project_dir.join("lv_drivers");
 
     let lv_config_dir = {
-        let conf_path = env::var(CONFIG_NAME)
-            .map(PathBuf::from)
-            .unwrap_or_else(|_| {
-                panic!(
-                    "The environment variable {} is required to be defined",
-                    CONFIG_NAME
-                );
-            });
+        let conf_path = env::var(CONFIG_NAME).map(PathBuf::from).unwrap_or_else(|_| {
+            // On docs.rs the workspace .cargo/config.toml is unavailable, so
+            // fall back to the bundled default config to allow doc rendering.
+            if env::var("DOCS_RS").is_ok() {
+                return project_dir.join("default-conf");
+            }
+            panic!(
+                "The environment variable {} is required to be defined",
+                CONFIG_NAME
+            );
+        });
 
         if !conf_path.exists() {
             panic!(

--- a/oxivgl-sys/default-conf/lv_conf.h
+++ b/oxivgl-sys/default-conf/lv_conf.h
@@ -1,0 +1,430 @@
+/**
+ * @file lv_conf.h
+ * Configuration file for LVGL v9.5.0 (alternator-regulator project)
+ * Ported from v8.4 config.
+ */
+
+/* clang-format off */
+#if 1 /*Set it to "1" to enable content*/
+
+#ifndef LV_CONF_H
+#define LV_CONF_H
+
+/*====================
+   COLOR SETTINGS
+ *====================*/
+
+/*Color depth: 1 (I1), 8 (L8), 16 (RGB565), 24 (RGB888), 32 (XRGB8888)*/
+#define LV_COLOR_DEPTH 16
+
+/*=========================
+   STDLIB WRAPPER SETTINGS
+ *=========================*/
+
+/* Use standard C malloc/free (was LV_MEM_CUSTOM=1 in v8) */
+#define LV_USE_STDLIB_MALLOC    LV_STDLIB_CLIB
+#define LV_USE_STDLIB_STRING    LV_STDLIB_CLIB
+#define LV_USE_STDLIB_SPRINTF   LV_STDLIB_BUILTIN
+
+/*====================
+   HAL SETTINGS
+ *====================*/
+
+/*Default display refresh period.*/
+#define LV_DEF_REFR_PERIOD  32      /*[ms]*/
+
+#define LV_DPI_DEF 130     /*[px/inch]*/
+
+/*=================
+ * OPERATING SYSTEM
+ *=================*/
+#define LV_USE_OS   LV_OS_NONE
+
+/*========================
+ * RENDERING CONFIGURATION
+ *========================*/
+
+#define LV_DRAW_BUF_STRIDE_ALIGN                1
+#define LV_DRAW_BUF_ALIGN                       4
+
+#define LV_DRAW_TRANSFORM_USE_MATRIX            0
+
+#define LV_DRAW_LAYER_MAX_MEMORY         0             /*[bytes] 0=no limit*/
+#define LV_DRAW_LAYER_SIMPLE_BUF_SIZE    (24 * 1024)   /*[bytes]*/
+#define LV_DRAW_THREAD_STACK_SIZE    (8 * 1024)   /*[bytes]*/
+
+#define LV_USE_DRAW_SW 1
+#if LV_USE_DRAW_SW == 1
+    #define LV_DRAW_SW_SUPPORT_RGB565       1
+    #define LV_DRAW_SW_SUPPORT_RGB565_SWAPPED 1
+    #define LV_DRAW_SW_SUPPORT_RGB565A8     1
+    #define LV_DRAW_SW_SUPPORT_RGB888       1
+    #define LV_DRAW_SW_SUPPORT_XRGB8888    0
+    #define LV_DRAW_SW_SUPPORT_ARGB8888    1
+    #define LV_DRAW_SW_SUPPORT_ARGB8888_PREMULTIPLIED 1
+    #define LV_DRAW_SW_SUPPORT_L8          0
+    #define LV_DRAW_SW_SUPPORT_AL88        0
+    #define LV_DRAW_SW_SUPPORT_A8          1
+    #define LV_DRAW_SW_SUPPORT_I1          0
+
+    #define LV_DRAW_SW_DRAW_UNIT_CNT    1
+    #define LV_USE_DRAW_ARM2D_SYNC      0
+    #define LV_USE_NATIVE_HELIUM_ASM    0
+
+    #define LV_DRAW_SW_COMPLEX          1
+    #if LV_DRAW_SW_COMPLEX == 1
+        #define LV_DRAW_SW_SHADOW_CACHE_SIZE 16
+        #define LV_DRAW_SW_CIRCLE_CACHE_SIZE 4
+    #endif
+
+    #define  LV_USE_DRAW_SW_ASM     LV_DRAW_SW_ASM_NONE
+    #define LV_USE_DRAW_SW_COMPLEX_GRADIENTS    1
+#endif
+
+#define LV_USE_DRAW_VGLITE 0
+#define LV_USE_PXP 0
+#define LV_USE_DRAW_DAVE2D 0
+#define LV_USE_DRAW_SDL 0
+#define LV_USE_DRAW_VG_LITE 0
+
+/*=======================
+ * FEATURE CONFIGURATION
+ *=======================*/
+
+/*-------------
+ * Logging
+ *-----------*/
+
+#define LV_USE_LOG 1
+#if LV_USE_LOG
+    #define LV_LOG_LEVEL LV_LOG_LEVEL_INFO
+    #define LV_LOG_PRINTF 0
+    #define LV_LOG_USE_TIMESTAMP 1
+    #define LV_LOG_USE_FILE_LINE 1
+
+    #define LV_LOG_TRACE_MEM        0
+    #define LV_LOG_TRACE_TIMER      0
+    #define LV_LOG_TRACE_INDEV      0
+    #define LV_LOG_TRACE_DISP_REFR  0
+    #define LV_LOG_TRACE_EVENT      0
+    #define LV_LOG_TRACE_OBJ_CREATE 1
+    #define LV_LOG_TRACE_LAYOUT     1
+    #define LV_LOG_TRACE_ANIM       0
+    #define LV_LOG_TRACE_CACHE      0
+#endif  /*LV_USE_LOG*/
+
+/*-------------
+ * Asserts
+ *-----------*/
+
+#define LV_USE_ASSERT_NULL          1
+#define LV_USE_ASSERT_MALLOC        1
+#define LV_USE_ASSERT_STYLE         0
+#define LV_USE_ASSERT_MEM_INTEGRITY 0
+#define LV_USE_ASSERT_OBJ           0
+
+#define LV_ASSERT_HANDLER_INCLUDE <stdint.h>
+#define LV_ASSERT_HANDLER while(1);   /*Halt by default*/
+
+/*-------------
+ * Debug
+ *-----------*/
+
+#define LV_USE_REFR_DEBUG 0
+#define LV_USE_LAYER_DEBUG 0
+#define LV_USE_PARALLEL_DRAW_DEBUG 0
+
+/*-------------
+ * Others
+ *-----------*/
+
+#define LV_ENABLE_GLOBAL_CUSTOM 0
+
+#define LV_CACHE_DEF_SIZE       0
+#define LV_IMAGE_HEADER_CACHE_DEF_CNT 0
+#define LV_GRADIENT_MAX_STOPS   8
+#define LV_COLOR_MIX_ROUND_OFS  0
+#define LV_OBJ_STYLE_CACHE      0
+#define LV_USE_OBJ_ID           0
+#define LV_OBJ_ID_AUTO_ASSIGN   LV_USE_OBJ_ID
+#define LV_USE_OBJ_ID_BUILTIN   1
+#define LV_USE_OBJ_PROPERTY 0
+#define LV_USE_OBJ_PROPERTY_NAME 0
+#define LV_USE_VG_LITE_THORVG  0
+
+/*=====================
+ *  COMPILER SETTINGS
+ *====================*/
+
+#define LV_BIG_ENDIAN_SYSTEM 0
+
+#define LV_ATTRIBUTE_TICK_INC
+#define LV_ATTRIBUTE_TIMER_HANDLER
+#define LV_ATTRIBUTE_FLUSH_READY
+
+#define LV_ATTRIBUTE_MEM_ALIGN_SIZE 4
+#define LV_ATTRIBUTE_MEM_ALIGN  __attribute__((aligned(4)))
+#define LV_ATTRIBUTE_LARGE_CONST
+#define LV_ATTRIBUTE_LARGE_RAM_ARRAY
+#define LV_ATTRIBUTE_FAST_MEM
+
+#define LV_EXPORT_CONST_INT(int_value) struct _silence_gcc_warning
+#define LV_ATTRIBUTE_EXTERN_DATA
+
+#define LV_USE_FLOAT            1
+#define LV_USE_MATRIX           1
+#define LV_USE_PRIVATE_API      1
+
+/*==================
+ *   FONT USAGE
+ *===================*/
+
+#define LV_FONT_MONTSERRAT_8  1
+#define LV_FONT_MONTSERRAT_10 1
+#define LV_FONT_MONTSERRAT_12 1
+#define LV_FONT_MONTSERRAT_14 1
+#define LV_FONT_MONTSERRAT_16 1
+#define LV_FONT_MONTSERRAT_18 1
+#define LV_FONT_MONTSERRAT_20 1
+#define LV_FONT_MONTSERRAT_22 1
+#define LV_FONT_MONTSERRAT_24 1
+#define LV_FONT_MONTSERRAT_26 1
+#define LV_FONT_MONTSERRAT_28 1
+#define LV_FONT_MONTSERRAT_30 1
+#define LV_FONT_MONTSERRAT_32 1
+#define LV_FONT_MONTSERRAT_34 1
+#define LV_FONT_MONTSERRAT_36 1
+#define LV_FONT_MONTSERRAT_38 1
+#define LV_FONT_MONTSERRAT_40 1
+#define LV_FONT_MONTSERRAT_42 1
+#define LV_FONT_MONTSERRAT_44 1
+#define LV_FONT_MONTSERRAT_46 1
+#define LV_FONT_MONTSERRAT_48 1
+
+#define LV_FONT_MONTSERRAT_28_COMPRESSED 0
+#define LV_FONT_DEJAVU_16_PERSIAN_HEBREW 1
+#define LV_FONT_SOURCE_HAN_SANS_SC_14_CJK 1
+#define LV_FONT_SOURCE_HAN_SANS_SC_16_CJK 1
+
+#define LV_FONT_UNSCII_8  0
+#define LV_FONT_UNSCII_16 0
+
+#define LV_FONT_CUSTOM_DECLARE
+
+#define LV_FONT_DEFAULT &lv_font_montserrat_14
+#define LV_FONT_FMT_TXT_LARGE 0
+#define LV_USE_FONT_COMPRESSED 0
+#define LV_USE_FONT_PLACEHOLDER 1
+
+/*=================
+ *  TEXT SETTINGS
+ *=================*/
+
+#define LV_TXT_ENC LV_TXT_ENC_UTF8
+#define LV_TXT_BREAK_CHARS " ,.;:-_"
+#define LV_TXT_LINE_BREAK_LONG_LEN 0
+#define LV_TXT_LINE_BREAK_LONG_PRE_MIN_LEN 3
+#define LV_TXT_LINE_BREAK_LONG_POST_MIN_LEN 3
+
+#define LV_USE_BIDI 1
+#define LV_USE_ARABIC_PERSIAN_CHARS 0
+
+/*==================
+ * WIDGETS
+ *================*/
+
+#define LV_WIDGETS_HAS_DEFAULT_VALUE  1
+
+#define LV_USE_ANIMIMG    1
+#define LV_USE_ARC        1
+#define LV_USE_ARCLABEL   1
+#define LV_USE_BAR        1
+#define LV_USE_BUTTON        1
+#define LV_USE_BUTTONMATRIX  1
+#define LV_USE_CALENDAR   1
+#define LV_USE_CALENDAR_CHINESE         1
+#if LV_USE_CALENDAR
+    #define LV_CALENDAR_WEEK_STARTS_MONDAY 0
+    #if LV_CALENDAR_WEEK_STARTS_MONDAY
+        #define LV_CALENDAR_DEFAULT_DAY_NAMES {"Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"}
+    #else
+        #define LV_CALENDAR_DEFAULT_DAY_NAMES {"Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"}
+    #endif
+    #define LV_CALENDAR_DEFAULT_MONTH_NAMES {"January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"}
+    #define LV_USE_CALENDAR_HEADER_ARROW    1
+    #define LV_USE_CALENDAR_HEADER_DROPDOWN 1
+#endif
+#define LV_USE_CANVAS     1
+#define LV_USE_CHART      1
+#define LV_USE_CHECKBOX   1
+#define LV_USE_DROPDOWN   1
+#define LV_USE_IMAGE      1
+#define LV_USE_IMAGEBUTTON     1
+#define LV_USE_KEYBOARD   1
+#define LV_USE_LABEL      1
+#if LV_USE_LABEL
+    #define LV_LABEL_TEXT_SELECTION 1
+    #define LV_LABEL_LONG_TXT_HINT 1
+    #define LV_LABEL_WAIT_CHAR_COUNT 3
+#endif
+#define LV_USE_LED        1
+#define LV_USE_LINE       1
+#define LV_USE_LIST       1
+#define LV_USE_LOTTIE     0
+#define LV_USE_MENU       1
+#define LV_USE_MSGBOX     1
+#define LV_USE_ROLLER     1
+#define LV_USE_SCALE      1
+#define LV_USE_SLIDER     1
+#define LV_USE_SPAN       1
+#define LV_USE_SPINBOX    1
+#define LV_USE_SPINNER    1
+#define LV_USE_SWITCH     1
+#define LV_USE_TEXTAREA   1
+#define LV_USE_TABLE      1
+#define LV_USE_TABVIEW    1
+#define LV_USE_TILEVIEW   1
+#define LV_USE_WIN        1
+
+/*==================
+ * THEMES
+ *==================*/
+
+#define LV_USE_THEME_DEFAULT 1
+#if LV_USE_THEME_DEFAULT
+    #define LV_THEME_DEFAULT_DARK 0
+    #define LV_THEME_DEFAULT_GROW 1
+    #define LV_THEME_DEFAULT_TRANSITION_TIME 80
+#endif
+
+#define LV_USE_THEME_SIMPLE 1
+#define LV_USE_THEME_MONO 1
+
+/*==================
+ * LAYOUTS
+ *==================*/
+
+#define LV_USE_FLEX 1
+#define LV_USE_GRID 1
+
+/*====================
+ * 3RD PARTS LIBRARIES
+ *====================*/
+
+#define LV_FS_DEFAULT_DRIVER_LETTER '\0'
+#define LV_USE_FS_STDIO 0
+#define LV_USE_FS_POSIX 0
+#define LV_USE_FS_WIN32 0
+#define LV_USE_FS_FATFS 0
+#define LV_USE_FS_MEMFS 0
+#define LV_USE_FS_LITTLEFS 0
+#define LV_USE_FS_ARDUINO_ESP_LITTLEFS 0
+#define LV_USE_FS_ARDUINO_SD 0
+
+#define LV_USE_LODEPNG 0
+#define LV_USE_LIBPNG 0
+#define LV_USE_BMP 0
+#define LV_USE_TJPGD 0
+#define LV_USE_LIBJPEG_TURBO 0
+#define LV_USE_GIF 0
+#define LV_BIN_DECODER_RAM_LOAD 0
+#define LV_USE_RLE 0
+#define LV_USE_QRCODE 0
+#define LV_USE_BARCODE 0
+#define LV_USE_FREETYPE 0
+#define LV_USE_TINY_TTF 0
+#define LV_USE_RLOTTIE 0
+#define LV_USE_VECTOR_GRAPHIC  0
+#define LV_USE_THORVG_INTERNAL 0
+#define LV_USE_THORVG_EXTERNAL 0
+#define LV_USE_LZ4_INTERNAL  0
+#define LV_USE_LZ4_EXTERNAL  0
+#define LV_USE_FFMPEG 0
+
+/*==================
+ * OTHERS
+ *==================*/
+
+#ifdef __xtensa__
+#define LV_USE_SNAPSHOT 0
+#else
+#define LV_USE_SNAPSHOT 1
+#endif
+#define LV_USE_SYSMON   1
+#if LV_USE_SYSMON
+//    #define LV_SYSMON_GET_IDLE lv_timer_get_idle
+    #define LV_USE_PERF_MONITOR 1
+    #if LV_USE_PERF_MONITOR
+        #define LV_USE_PERF_MONITOR_POS LV_ALIGN_TOP_LEFT
+        #define LV_USE_PERF_MONITOR_LOG_MODE 0
+    #endif
+    #define LV_USE_MEM_MONITOR 0
+#endif
+#define LV_USE_PROFILER 0
+#define LV_USE_MONKEY 0
+#define LV_USE_GRIDNAV 1
+#define LV_USE_FRAGMENT 0
+#define LV_USE_IMGFONT 0
+#define LV_USE_OBSERVER 1
+#define LV_USE_IME_PINYIN 0
+#define LV_USE_FILE_EXPLORER 0
+#define LV_USE_TRANSLATION 1
+
+/*==================
+ * DEVICES
+ *==================*/
+
+#ifdef __xtensa__
+#define LV_USE_SDL              0
+#else
+#define LV_USE_SDL              1
+#define LV_SDL_RENDER_MODE      LV_DISPLAY_RENDER_MODE_DIRECT
+#define LV_SDL_BUF_COUNT        2
+#define LV_SDL_DIRECT_EXIT      1
+#endif
+#define LV_USE_X11              0
+#define LV_USE_WAYLAND          0
+#define LV_USE_LINUX_FBDEV      0
+#define LV_USE_NUTTX    0
+#define LV_USE_LINUX_DRM        0
+#define LV_USE_TFT_ESPI         0
+#define LV_USE_EVDEV    0
+#define LV_USE_LIBINPUT    0
+#define LV_USE_ST7735        0
+#define LV_USE_ST7789        0
+#define LV_USE_ST7796        0
+#define LV_USE_ILI9341       0
+#define LV_USE_GENERIC_MIPI (LV_USE_ST7735 | LV_USE_ST7789 | LV_USE_ST7796 | LV_USE_ILI9341)
+#define LV_USE_RENESAS_GLCDC    0
+#define LV_USE_WINDOWS    0
+#define LV_USE_OPENGLES   0
+#define LV_USE_QNX              0
+
+/*==================
+* EXAMPLES
+*==================*/
+
+#define LV_BUILD_EXAMPLES 0
+#define LV_BUILD_DEMOS 0
+
+/*===================
+ * DEMO USAGE
+ ====================*/
+
+#define LV_USE_DEMO_WIDGETS 0
+#define LV_USE_DEMO_KEYPAD_AND_ENCODER 0
+#define LV_USE_DEMO_BENCHMARK 0
+#define LV_USE_DEMO_RENDER 0
+#define LV_USE_DEMO_STRESS 0
+#define LV_USE_DEMO_MUSIC 0
+#define LV_USE_DEMO_FLEX_LAYOUT     0
+#define LV_USE_DEMO_MULTILANG       0
+#define LV_USE_DEMO_TRANSFORM       0
+#define LV_USE_DEMO_SCROLL          0
+#define LV_USE_DEMO_VECTOR_GRAPHIC  0
+
+/*--END OF LV_CONF_H--*/
+
+#endif /*LV_CONF_H*/
+
+#endif /*End of "Content enable"*/


### PR DESCRIPTION
## Summary

The v0.1.0 docs.rs build failed because the workspace `.cargo/config.toml` that sets `DEP_LV_CONFIG_PATH` is not shipped with the published crate. The existing `DOCS_RS` short-circuit in `oxivgl-sys/build.rs` emitted empty bindings, which then broke compilation of `oxivgl` (missing FFI symbols like `lv_font_montserrat_12`).

## Changes

- **`oxivgl-sys`**: bundle `default-conf/lv_conf.h` and fall back to it when `DEP_LV_CONFIG_PATH` is unset under `DOCS_RS=1`. Removed the broken empty-bindings shortcut so real bindings are generated.
- **`oxivgl/build.rs`**: skip image asset compilation under `DOCS_RS=1` (doc rendering doesn't need compiled C image assets).
- **Version bump**: `oxivgl` and `oxivgl-sys` → `0.1.1`. CHANGELOG updated.

The user-supplied-`lv_conf.h` model from `CLAUDE.md` is preserved — the bundled default only kicks in when both `DEP_LV_CONFIG_PATH` is unset AND `DOCS_RS` is set, so regular consumers still get a clear error if they forget to provide config.

## Test plan

- [x] `cargo check` on host
- [x] Simulated docs.rs build (`DOCS_RS=1 cargo doc --no-default-features --features log-04,png`, with `.cargo/config.toml` removed) succeeds and renders docs

After merge: publish v0.1.1 of `oxivgl-sys` then `oxivgl` to crates.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)