### PR TITLE
chore: bump esp-hal to 1.1.0 and align embassy ecosystem

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,13 +39,13 @@ png = ["dep:png"]
 
 [dependencies]
 oxivgl_sys = { package = "oxivgl-sys", version = "0.1.2", path = "oxivgl-sys", default-features = false }
-embassy-sync = "0.7.2"
+embassy-sync = "0.8"
 embassy-time = "0.5.0"
 heapless = { version = "0.9.1", features = ["nightly"] }
 cfg-if = "1"
 thiserror-no-std = "2.0.2"
 critical-section = "1"
-esp-hal = { version = "1.0.0", features = ["unstable"], optional = true }
+esp-hal = { version = "1.1.0", features = ["unstable"], optional = true }
 defmt = { version = "1.0.1", optional = true }
 log-04 = { package = "log", version = "0.4", optional = true }
 png = { version = "0.17", optional = true }
@@ -62,10 +62,10 @@ oxivgl_sys = { package = "oxivgl-sys", version = "0.1.2", path = "oxivgl-sys", d
 
 # Proc-macro crates needed by fire27_main! attribute/macro expansion on xtensa
 [target.'cfg(target_arch = "xtensa")'.dev-dependencies]
-embassy-executor       = { version = "0.9.1", features = ["nightly"] }
-esp-bootloader-esp-idf = { version = "0.4.0", features = ["esp32"] }
-esp-hal                = { version = "=1.0.0", features = ["esp32", "unstable"] }
-esp-rtos               = { version = "0.2.0", features = ["esp32", "embassy"] }
+embassy-executor       = { version = "0.10.0", features = ["nightly"] }
+esp-bootloader-esp-idf = { version = "0.5.0", features = ["esp32"] }
+esp-hal                = { version = "=1.1.0", features = ["esp32", "unstable"] }
+esp-rtos               = { version = "0.3.0", features = ["esp32", "embassy"] }
 
 [profile.dev]
 opt-level = "s"

--- a/examples/common/Cargo.toml
+++ b/examples/common/Cargo.toml
@@ -17,16 +17,16 @@ heapless = { version = "0.8" }
 [target.'cfg(target_arch = "xtensa")'.dependencies]
 oxivgl = { path = "../..", features = ["esp-hal", "esp32", "log-04"] }
 oxivgl_sys = { package = "oxivgl-sys", path = "../../oxivgl-sys", default-features = false }
-esp-alloc            = { version = "0.9.0", features = ["internal-heap-stats"] }
+esp-alloc            = { version = "0.10.0", features = ["esp32", "internal-heap-stats"] }
 esp-backtrace        = { version = "0.18.1", features = ["esp32", "panic-handler", "custom-halt", "colors", "println"] }
-esp-bootloader-esp-idf = { version = "0.4.0", features = ["esp32"] }
-esp-hal              = { version = "=1.0.0", features = ["esp32", "unstable"] }
+esp-bootloader-esp-idf = { version = "0.5.0", features = ["esp32"] }
+esp-hal              = { version = "=1.1.0", features = ["esp32", "unstable"] }
 esp-println          = { version = "0.16.1", features = ["esp32", "log-04", "colors", "uart"], default-features = false }
-esp-rtos             = { version = "0.2.0", features = ["esp32", "embassy"] }
-esp-sync             = { version = "0.1.1", features = ["esp32"] }
-embassy-embedded-hal = { version = "0.5.0", features = ["time"] }
-embassy-executor     = { version = "0.9.1", features = ["nightly"] }
-embassy-sync         = "0.7.2"
+esp-rtos             = { version = "0.3.0", features = ["esp32", "embassy"] }
+esp-sync             = { version = "0.2.1", features = ["esp32"] }
+embassy-embedded-hal = { version = "0.6.0", features = ["time"] }
+embassy-executor     = { version = "0.10.0", features = ["nightly"] }
+embassy-sync         = "0.8"
 embassy-time         = "0.5.0"
 lcd-async            = "0.1.1"
 log                  = "0.4"

--- a/examples/common/src/fire27.rs
+++ b/examples/common/src/fire27.rs
@@ -40,6 +40,25 @@ macro_rules! fire27_main_nav {
     };
 }
 
+/// Spawn a task, panicking with call-site context if the task pool is exhausted.
+///
+/// Replaces embassy-executor's `Spawner::must_spawn`, which was removed in
+/// 0.10.0 when `spawn` became infallible and the `Result` moved to the task
+/// function itself. For one-shot init code with `pool_size = 1` (the default),
+/// the failure is a logic bug, so panicking is the right behavior.
+///
+/// Works with both `Spawner` and `SendSpawner` (duck-typed on `.spawn()`).
+#[macro_export]
+#[doc(hidden)]
+macro_rules! must_spawn {
+    ($spawner:expr, $task:expr) => {
+        $spawner.spawn(
+            $task.unwrap_or_else(|e| panic!(
+                concat!("spawn ", stringify!($task), ": {:?}"), e))
+        )
+    };
+}
+
 /// Internal: shared Fire27 hardware setup body. Do not call directly.
 ///
 /// `$mode` is either `single` (uses `run_app`) or `nav` (uses `run_app_nav`).
@@ -251,7 +270,7 @@ macro_rules! fire27_body {
 
             let tg0 = TimerGroup::new(p.TIMG0);
             let sw_int = SoftwareInterruptControl::new(p.SW_INTERRUPT);
-            esp_rtos::start(tg0.timer0);
+            esp_rtos::start(tg0.timer0, sw_int.software_interrupt0);
             info!("Embassy initialized");
 
             // Configure hardware buttons (active-low, external pull-ups on GPIO34-39).
@@ -261,12 +280,12 @@ macro_rules! fire27_body {
             let btn_c = Input::new(p.GPIO37, InputConfig::default()); // C — NEXT
 
             // Spawn one task per button before the LVGL loop starts.
-            _low_prio_spawner
-                .must_spawn(button_task(btn_a, $crate::oxivgl::enums::Key::PREV.0));
-            _low_prio_spawner
-                .must_spawn(button_task(btn_b, $crate::oxivgl::enums::Key::ENTER.0));
-            _low_prio_spawner
-                .must_spawn(button_task(btn_c, $crate::oxivgl::enums::Key::NEXT.0));
+            $crate::must_spawn!(_low_prio_spawner,
+                button_task(btn_a, $crate::oxivgl::enums::Key::PREV.0));
+            $crate::must_spawn!(_low_prio_spawner,
+                button_task(btn_b, $crate::oxivgl::enums::Key::ENTER.0));
+            $crate::must_spawn!(_low_prio_spawner,
+                button_task(btn_c, $crate::oxivgl::enums::Key::NEXT.0));
 
             let spi_config = SpiConfig::default()
                 .with_frequency(Rate::from_khz(40_000))
@@ -308,7 +327,7 @@ macro_rules! fire27_body {
             let int_exec =
                 make_static!(InterruptExecutor::new(sw_int.software_interrupt1));
             let hi_spawner = int_exec.start(Priority::min());
-            hi_spawner.must_spawn(flush_task(driver));
+            $crate::must_spawn!(hi_spawner, flush_task(driver));
 
             static mut LVGL_BUFS: LvglBuffers<LVGL_BUF_BYTES> = LvglBuffers::new();
             // SAFETY: LVGL_BUFS is only accessed here, before the single-threaded


### PR DESCRIPTION
## Summary

Updates esp-hal from 1.0.0 to 1.1.0 and brings the rest of the embassy/Espressif ecosystem along with it. Removes the version pin added in #4f9b848.

## Dependency bumps

| Crate | From | To | Reason |
|---|---|---|---|
| esp-hal | 1.0.0 | 1.1.0 | requested upgrade |
| esp-rtos | 0.2.0 | 0.3.0 | needs embassy-sync 0.8 + embassy-executor 0.10 |
| embassy-executor | 0.9.1 | 0.10.0 | esp-rtos 0.3 requirement |
| embassy-sync | 0.7.2 | 0.8 | esp-hal 1.1 requirement |
| embassy-embedded-hal | 0.5.0 | 0.6.0 | esp-hal 1.1 requirement (root cause of prior pin) |
| esp-bootloader-esp-idf | 0.4.0 | 0.5.0 | matches esp-hal-procmacros 0.22; needed for `#[ram(reclaimed)]` |
| esp-alloc | 0.9.0 | 0.10.0 | esp32 feature now explicit; pulls esp-sync 0.2 |
| esp-sync | 0.1.1 | 0.2.1 | impls `RawMutex` for embassy-sync 0.6/0.7/0.8 simultaneously |

## Source changes (`examples/common/src/fire27.rs`)

- `esp_rtos::start(timer)` → `esp_rtos::start(timer, sw_int.software_interrupt0)`
- embassy-executor 0.10 dropped `Spawner::must_spawn`; `spawn` now takes a `SpawnToken` directly (the `#[task]` macro returns `Result<SpawnToken, SpawnError>`). Call sites use `.unwrap()` on the task result.

## SPI/DMA review

Audited esp-hal 1.1.0 changelog for SPI/DMA breaking changes — none affect us. Our path (`Spi::new(...).into_async()` → `SpiDeviceWithConfig` via `embedded-hal-async`) is unchanged. Quietly inherits two upstream bug fixes: `SpiBus::transfer` no longer over-writes, and `SpiDma` now drops bus/buffer correctly on transfer-object drop.

## Test plan

- [x] `cargo check` (host) clean
- [x] `cargo +esp -Zbuild-std=alloc,core build --release --example {anim1,nav1,getting_started1}` for `xtensa-esp32-none-elf`
- [x] `./run_tests.sh unit` — 36 passed
- [x] `./run_tests.sh int` — 489 passed
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)