### PR TITLE
feat: navigator OSD enablement (backdrop + focus push/pop + register_events_on)

### DIFF
--- a/docs/spec-navigation.md
+++ b/docs/spec-navigation.md
@@ -131,6 +131,26 @@ pub trait View: 'static {
     ///
     /// Default is a no-op.
     fn did_show(&mut self) {}
+
+    /// Register event handlers. Called once after `create`, with the
+    /// same `container` that was passed to `create`. Default attaches
+    /// the view's event trampoline to `container`, so bubbled events
+    /// from any descendant reach `on_event`.
+    ///
+    /// Receiving `container` as an argument — rather than reading
+    /// `lv_screen_active()` — makes the default correct for modals as
+    /// well as full-screen views: the navigator passes the modal
+    /// backdrop, the toast container, or the screen, whichever applies.
+    fn register_events_on(&mut self, container: &Obj<'static>) {
+        register_event_on(self, container.lv_handle());
+    }
+
+    /// Focus group containing this view's focusable widgets (modals
+    /// only). When non-`None`, the navigator activates this group on
+    /// modal open (sets it as default + binds it to all KEYPAD /
+    /// ENCODER input devices) and restores the previous focus state on
+    /// dismiss. Default `None`. See §4.2 for the full lifecycle.
+    fn input_group(&self) -> Option<GroupRef> { None }
 }
 ```
 
@@ -196,8 +216,13 @@ overlays.
 pub struct Navigator {
     // Full-screen navigation stack. Index 0 is the root view.
     stack: Vec<ViewEntry>,
-    // Currently active modal, if any. Rendered on lv_layer_top().
+    // Currently active modal, if any. Rendered inside `modal_backdrop`
+    // which itself is a child of lv_layer_top().
     modal: Option<Box<dyn AnyView>>,
+    modal_backdrop: Option<Obj<'static>>,
+    // Focus state captured on modal open (if input_group was Some);
+    // restored on dismiss. See §4.2.
+    saved_focus: Option<SavedFocus>,
     // Currently active global toast, if any. Rendered as a child of
     // lv_layer_sys(). See §4.3.
     toast: Option<Box<dyn AnyView>>,
@@ -279,11 +304,46 @@ creates a full-size `Obj` on `lv_layer_top()` with
 `ObjFlag::CLICKABLE` set. This absorbs all touch/click events,
 preventing them from reaching the view below. The modal's widgets are
 then created as children of this backdrop object. Dismissing the modal
-deletes the backdrop and all its children.
+drops the backdrop `Obj`, which cascades the deletion to every modal
+widget — a single root, no `lv_obj_clean(layer_top)` needed.
 
 Optional: the backdrop can be styled with a semi-transparent dark fill
-(`opa(128)`, `bg_color(Color::black())`) for a standard dim effect.
-This is a `ScreenAnim` option, not automatic.
+(`opa(128)`, `bg_color(Color::black())`) on the modal's own widgets
+for a standard dim effect. The backdrop itself is transparent.
+
+**Event registration.** `View::register_events_on` defaults to attaching
+the trampoline on the container the navigator passed — which for a
+modal is the backdrop, **not** `lv_screen_active()`. This is what
+makes default modal event handling correct: every bubbled event from a
+modal widget reaches the modal's `on_event`, and no handlers are
+attached to the background view's screen (where they would dangle on a
+push/pop transition).
+
+Modals that catch events on intermediate widgets (containers that don't
+auto-bubble) can still override `register_events_on` and call
+`register_event_on(self, intermediate.handle())` for those.
+
+**Focus management (OSD-style modals).** A modal that needs keyboard or
+encoder input — e.g. an on-screen menu the user navigates with hardware
+buttons — owns its own [`Group`](../src/group.rs) and exposes it via
+`View::input_group`. The navigator does the rest:
+
+1. **On `modal()` open**, if `view.input_group()` returns `Some(group)`:
+   - capture the current default group + the per-indev (KEYPAD /
+     ENCODER) group bindings into a private `SavedFocus`;
+   - call `group.set_default()`;
+   - call `group.assign_to_keyboard_indevs()`.
+
+2. **On `dismiss_modal()`**, the captured `SavedFocus` is restored:
+   - previous default group reinstated via `lv_group_set_default`;
+   - each previously-bound indev re-bound to its previous group via
+     `lv_indev_set_group`.
+
+The app never has to touch `lv_indev_*` / `lv_group_set_default`
+directly, and key events route to the OSD while it is open and back to
+the background view as soon as it is dismissed. A modal that does *not*
+need key input simply returns `None` from `input_group` (the default)
+and the navigator leaves focus state untouched.
 
 ### 4.3 Global Status Overlay (Toast)
 

--- a/examples/canvas_1.rs
+++ b/examples/canvas_1.rs
@@ -61,7 +61,7 @@ impl View for Canvas1 {
         Ok(())
     }
 
-    fn register_events(&mut self) {}
+    fn register_events_on(&mut self, _container: &Obj<'static>) {}
     fn on_event(&mut self, _: &oxivgl::event::Event) -> NavAction { NavAction::None }
 
     fn update(&mut self) -> Result<NavAction, WidgetError> {

--- a/examples/canvas_6.rs
+++ b/examples/canvas_6.rs
@@ -41,7 +41,7 @@ impl View for Canvas6 {
         Ok(())
     }
 
-    fn register_events(&mut self) {}
+    fn register_events_on(&mut self, _container: &Obj<'static>) {}
     fn on_event(&mut self, _: &oxivgl::event::Event) -> NavAction { NavAction::None }
 
     fn update(&mut self) -> Result<NavAction, WidgetError> {

--- a/examples/common/src/fire27.rs
+++ b/examples/common/src/fire27.rs
@@ -253,8 +253,8 @@ macro_rules! fire27_body {
                 self.inner.on_event(event)
             }
 
-            fn register_events_on(&mut self, _container: &Obj<'static>) {
-                self.inner.register_events();
+            fn register_events_on(&mut self, container: &Obj<'static>) {
+                self.inner.register_events_on(container);
             }
         }
 

--- a/examples/common/src/fire27.rs
+++ b/examples/common/src/fire27.rs
@@ -253,7 +253,7 @@ macro_rules! fire27_body {
                 self.inner.on_event(event)
             }
 
-            fn register_events(&mut self) {
+            fn register_events_on(&mut self, _container: &Obj<'static>) {
                 self.inner.register_events();
             }
         }

--- a/examples/common/src/host.rs
+++ b/examples/common/src/host.rs
@@ -165,7 +165,7 @@ macro_rules! host_main {
             let container = $crate::oxivgl::widgets::Obj::from_raw_non_owning(screen_handle);
             _view.create(&container).expect("view create failed");
 
-            $crate::oxivgl::view::register_view_events(&mut _view);
+            $crate::oxivgl::view::register_view_events(&mut _view, &container);
 
             // Derive screenshot name from source file path.
             let src = file!();

--- a/examples/event_bubble.rs
+++ b/examples/event_bubble.rs
@@ -57,7 +57,7 @@ impl View for EventBubble {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         if let Some(ref cont) = self.cont {
             register_event_on(self, cont.handle());
         }

--- a/examples/event_button.rs
+++ b/examples/event_button.rs
@@ -43,7 +43,7 @@ impl View for EventButton {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         if let Some(ref btn) = self.btn { register_event_on(self, btn.handle()); }
     }
 

--- a/examples/event_draw.rs
+++ b/examples/event_draw.rs
@@ -40,7 +40,7 @@ impl View for EventDraw {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         if let Some(ref cont) = self.cont { register_event_on(self, cont.handle()); }
     }
 

--- a/examples/getting_started4.rs
+++ b/examples/getting_started4.rs
@@ -39,7 +39,7 @@ impl View for GettingStarted4 {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         if let Some(ref slider) = self.slider { register_event_on(self, slider.handle()); }
     }
 

--- a/examples/gridnav_3.rs
+++ b/examples/gridnav_3.rs
@@ -136,7 +136,7 @@ impl View for Gridnav3 {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         // Receive KEY events from cont_sub2 (no bubble needed — direct registration).
         if let Some(ref cont_sub2) = self.cont_sub2 {
             register_event_on(self, cont_sub2.handle());

--- a/examples/gridnav_4.rs
+++ b/examples/gridnav_4.rs
@@ -78,7 +78,7 @@ impl View for Gridnav4 {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         if let Some(ref list) = self.list {
             register_event_on(self, list.handle());
         }

--- a/examples/gridnav_5.rs
+++ b/examples/gridnav_5.rs
@@ -94,7 +94,7 @@ impl View for Gridnav5 {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         if let Some(ref ct) = self._cont_top { register_event_on(self, ct.handle()); }
         if let Some(ref cb) = self._cont_bot { register_event_on(self, cb.handle()); }
     }

--- a/examples/list_2.rs
+++ b/examples/list_2.rs
@@ -120,7 +120,7 @@ impl View for List2 {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         if let Some(ref list1) = self.list1 {
             register_event_on(self, list1.handle());
         }

--- a/examples/observer2.rs
+++ b/examples/observer2.rs
@@ -106,7 +106,7 @@ impl View for Observer2 {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         if let Some(ref ta) = self.ta { register_event_on(self, ta.handle()); }
         if let Some(ref btn_logout) = self.btn_logout { register_event_on(self, btn_logout.handle()); }
     }

--- a/examples/scroll6.rs
+++ b/examples/scroll6.rs
@@ -61,7 +61,7 @@ impl View for Scroll6 {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         if let Some(ref cont) = self.cont {
             register_event_on(self, cont.handle());
         }

--- a/examples/scroll7.rs
+++ b/examples/scroll7.rs
@@ -155,7 +155,7 @@ impl View for Scroll7 {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         if let Some(ref cont) = self.cont { register_event_on(self, cont.handle()); }
         if let Some(ref cb) = self.checkbox { register_event_on(self, cb.handle()); }
     }

--- a/examples/scroll8.rs
+++ b/examples/scroll8.rs
@@ -158,7 +158,7 @@ impl View for Scroll8 {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         if let Some(ref cont_row) = self.cont_row {
             register_event_on(self, cont_row.handle());
         }

--- a/examples/table_1.rs
+++ b/examples/table_1.rs
@@ -81,7 +81,7 @@ impl View for Table1 {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         if let Some(ref table) = self.table {
             register_event_on(self, table.handle());
         }

--- a/examples/table_2.rs
+++ b/examples/table_2.rs
@@ -68,7 +68,7 @@ impl View for Table2 {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         if let Some(ref table) = self.table {
             register_event_on(self, table.handle());
         }

--- a/examples/translation_2.rs
+++ b/examples/translation_2.rs
@@ -104,7 +104,7 @@ impl View for Translation2 {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         if let Some(ref dd) = self.dd {
             register_event_on(self, dd.handle());
         }

--- a/examples/widget_arc3.rs
+++ b/examples/widget_arc3.rs
@@ -153,7 +153,7 @@ impl View for WidgetArc3 {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         if let Some(ref arcs) = self.arcs {
             let handles: [_; NUM_SLICES] = core::array::from_fn(|i| arcs[i].handle());
             for h in handles {

--- a/examples/widget_bar6.rs
+++ b/examples/widget_bar6.rs
@@ -56,7 +56,7 @@ impl View for WidgetBar6 {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         if let Some(ref bar) = self.bar {
             register_event_on(self, bar.handle());
         }

--- a/examples/widget_button1.rs
+++ b/examples/widget_button1.rs
@@ -53,7 +53,7 @@ impl View for WidgetButton1 {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         if let Some(ref btn1) = self.btn1 { register_event_on(self, btn1.handle()); }
         if let Some(ref btn2) = self.btn2 { register_event_on(self, btn2.handle()); }
     }

--- a/examples/widget_buttonmatrix2.rs
+++ b/examples/widget_buttonmatrix2.rs
@@ -38,7 +38,7 @@ impl View for WidgetButtonmatrix2 {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         if let Some(ref btnm) = self.btnm {
             register_event_on(self, btnm.handle());
         }

--- a/examples/widget_chart4.rs
+++ b/examples/widget_chart4.rs
@@ -63,7 +63,7 @@ impl View for WidgetChart4 {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         if let Some(ref chart) = self.chart { register_event_on(self, chart.handle()); }
     }
 

--- a/examples/widget_checkbox2.rs
+++ b/examples/widget_checkbox2.rs
@@ -73,7 +73,7 @@ impl View for WidgetCheckbox2 {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         if let Some(ref g) = self.group1 {
             register_event_on(self, g.handle());
         }

--- a/examples/widget_dropdown1.rs
+++ b/examples/widget_dropdown1.rs
@@ -50,7 +50,7 @@ impl View for WidgetDropdown1 {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         if let Some(ref dd) = self.dd { register_event_on(self, dd.handle()); }
     }
 

--- a/examples/widget_keyboard3.rs
+++ b/examples/widget_keyboard3.rs
@@ -66,7 +66,7 @@ impl View for WidgetKeyboard3 {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         if let Some(ref kb) = self.kb {
             register_event_on(self, kb.handle());
         }

--- a/examples/widget_label7.rs
+++ b/examples/widget_label7.rs
@@ -86,7 +86,7 @@ impl View for WidgetLabel7 {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         if let Some(ref dd) = self.dd { register_event_on(self, dd.handle()); }
     }
 

--- a/examples/widget_list2.rs
+++ b/examples/widget_list2.rs
@@ -94,7 +94,7 @@ impl View for WidgetList2 {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         if let Some(ref list1) = self.list1 { register_event_on(self, list1.lv_handle()); }
         if let Some(ref list2) = self._list2 { register_event_on(self, list2.lv_handle()); }
     }

--- a/examples/widget_obj2.rs
+++ b/examples/widget_obj2.rs
@@ -38,7 +38,7 @@ impl View for WidgetObj2 {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         if let Some(ref obj) = self.obj {
             register_event_on(self, obj.handle());
         }

--- a/examples/widget_scale11.rs
+++ b/examples/widget_scale11.rs
@@ -174,7 +174,7 @@ impl View for WidgetScale11 {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         if let Some(ref scale) = self.scale {
             register_event_on(self, scale.handle());
         }

--- a/examples/widget_scale7.rs
+++ b/examples/widget_scale7.rs
@@ -95,7 +95,7 @@ impl View for WidgetScale7 {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         if let Some(ref scale) = self.scale { register_event_on(self, scale.handle()); }
     }
 

--- a/examples/widget_textarea1.rs
+++ b/examples/widget_textarea1.rs
@@ -58,7 +58,7 @@ impl View for WidgetTextarea1 {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         if let Some(ref btnm) = self.btnm {
             register_event_on(self, btnm.handle());
         }

--- a/examples/widget_textarea2.rs
+++ b/examples/widget_textarea2.rs
@@ -69,7 +69,7 @@ impl View for WidgetTextarea2 {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         if let Some(ref pwd_ta) = self.pwd_ta {
             register_event_on(self, pwd_ta.handle());
         }

--- a/examples/widget_textarea3.rs
+++ b/examples/widget_textarea3.rs
@@ -44,7 +44,7 @@ impl View for WidgetTextarea3 {
         Ok(())
     }
 
-    fn register_events(&mut self) {
+    fn register_events_on(&mut self, _container: &Obj<'static>) {
         if let Some(ref ta) = self.ta {
             register_event_on(self, ta.handle());
         }

--- a/src/group.rs
+++ b/src/group.rs
@@ -89,6 +89,15 @@ impl Group {
         self
     }
 
+    /// Borrow this group as a non-owning [`GroupRef`].
+    ///
+    /// Useful when handing the group to a navigator-style consumer that
+    /// only needs to swap focus into and out of it without taking
+    /// ownership.
+    pub fn as_ref(&self) -> GroupRef {
+        GroupRef { ptr: self.ptr, _not_send: PhantomData }
+    }
+
     /// Assign this group to all keyboard and encoder input devices.
     ///
     /// Iterates all registered indevs with `lv_indev_get_next` and calls
@@ -137,6 +146,38 @@ pub struct GroupRef {
 }
 
 impl GroupRef {
+    /// Set this group as the default group.
+    ///
+    /// Mirrors [`Group::set_default`] but operates on a non-owning handle —
+    /// useful for restoring a previously-captured default after a modal /
+    /// OSD overlay has hijacked it.
+    pub fn set_default(&self) -> &Self {
+        // SAFETY: self.ptr is non-null (checked by group_get_default /
+        // Group::as_ref). lv_group_set_default stores the pointer in a
+        // global.
+        unsafe { lv_group_set_default(self.ptr) };
+        self
+    }
+
+    /// Assign this group to all keyboard and encoder input devices.
+    /// Same semantics as [`Group::assign_to_keyboard_indevs`].
+    pub fn assign_to_keyboard_indevs(&self) -> &Self {
+        // SAFETY: same as Group::assign_to_keyboard_indevs.
+        unsafe {
+            let mut indev = lv_indev_get_next(core::ptr::null_mut());
+            while !indev.is_null() {
+                let kind = lv_indev_get_type(indev);
+                if kind == lv_indev_type_t_LV_INDEV_TYPE_KEYPAD
+                    || kind == lv_indev_type_t_LV_INDEV_TYPE_ENCODER
+                {
+                    lv_indev_set_group(indev, self.ptr);
+                }
+                indev = lv_indev_get_next(indev);
+            }
+        }
+        self
+    }
+
     /// Add a widget to this group.
     pub fn add_obj(&self, obj: &impl AsLvHandle) -> &Self {
         // SAFETY: self.ptr is non-null (checked in group_get_default()).

--- a/src/navigator.rs
+++ b/src/navigator.rs
@@ -49,8 +49,17 @@ struct ViewEntry {
 pub struct Navigator {
     /// Full-screen navigation stack. Index 0 is the root view.
     stack: Vec<ViewEntry>,
-    /// Currently active modal, if any. Rendered on `lv_layer_top()`.
+    /// Currently active modal, if any. Rendered as a child of the
+    /// modal backdrop on `lv_layer_top()`.
     modal: Option<Box<dyn AnyView>>,
+    /// Full-size click-absorbing backdrop the modal is built inside.
+    /// Dropping this `Obj` deletes the backdrop and (cascade) the modal
+    /// widget tree in one shot.
+    modal_backdrop: Option<Obj<'static>>,
+    /// Focus state captured when the active modal was opened — restored
+    /// on dismiss. `None` when no modal is active or when the modal did
+    /// not provide an [`input_group`](crate::view::View::input_group).
+    saved_focus: Option<SavedFocus>,
     /// Currently active global toast, if any. Rendered as a child of
     /// `lv_layer_sys()` so it persists across page switches and stays
     /// above any modal. See [`Navigator::show_toast`].
@@ -70,6 +79,8 @@ impl Navigator {
         Self {
             stack: Vec::new(),
             modal: None,
+            modal_backdrop: None,
+            saved_focus: None,
             toast: None,
             toast_container: None,
             toast_deadline_ms: None,
@@ -93,9 +104,9 @@ impl Navigator {
             .create(&container)
             .expect("root view create failed");
 
-        // register_events() default calls register_event_on(self, lv_screen_active()).
-        // lv_screen_active() is the default screen — correct at this point.
-        boxed.register_events();
+        // Default impl of register_events_on attaches the trampoline on
+        // `container` — the default screen at this point.
+        boxed.register_events_on(&container);
         boxed.did_show();
 
         self.stack.push(ViewEntry {
@@ -151,9 +162,9 @@ impl Navigator {
             .create(&new_screen)
             .expect("pushed view create failed");
 
-        // register_events() calls register_event_on(self, lv_screen_active()).
-        // Since we loaded new_screen above, lv_screen_active() == new_screen.
-        boxed.register_events();
+        // Default impl of register_events_on attaches on the new screen
+        // we just created and loaded.
+        boxed.register_events_on(&new_screen);
 
         // Clean the old screen's children (widget tree) to free memory,
         // but keep the screen object alive for potential pop animation.
@@ -226,7 +237,7 @@ impl Navigator {
             .create(&container)
             .map_err(NavigationError::CreateFailed)?;
 
-        top.view.register_events();
+        top.view.register_events_on(&container);
         top.view.did_show();
         Ok(())
     }
@@ -261,7 +272,7 @@ impl Navigator {
         boxed
             .create(&new_screen)
             .expect("replaced view create failed");
-        boxed.register_events();
+        boxed.register_events_on(&new_screen);
         boxed.did_show();
 
         self.stack.push(ViewEntry {
@@ -288,39 +299,84 @@ impl Navigator {
             let _ = self.dismiss_modal();
         }
 
-        let layer_top = Screen::layer_top();
+        // Create a full-size click-absorbing backdrop on lv_layer_top,
+        // then build the modal's widgets as children of the backdrop.
+        // This gives every modal automatic input absorption (touches on
+        // the backdrop never reach the view beneath) and a single root
+        // to delete on dismiss (deleting the backdrop cascades).
+        // SAFETY: lv_layer_top is a valid LVGL global after lv_init.
+        let layer_top_h = unsafe { lv_layer_top() };
+        assert!(!layer_top_h.is_null(), "lv_layer_top returned NULL");
+        // SAFETY: layer_top_h is non-null.
+        let backdrop_h = unsafe { lv_obj_create(layer_top_h) };
+        assert!(!backdrop_h.is_null(), "modal backdrop creation failed");
+        let backdrop = Obj::from_raw(backdrop_h);
+
+        // Full-size, click-absorbing, no scroll. Transparent fill so the
+        // background view stays visible unless the modal itself draws a
+        // dim layer.
+        // SAFETY: backdrop_h is the freshly-created object above.
+        unsafe {
+            let pct100 = lv_pct(100);
+            lv_obj_set_size(backdrop_h, pct100, pct100);
+            lv_obj_set_style_bg_opa(backdrop_h, 0, 0);
+            lv_obj_set_style_border_width(backdrop_h, 0, 0);
+            lv_obj_set_style_pad_all(backdrop_h, 0, 0);
+            lv_obj_add_flag(
+                backdrop_h,
+                crate::enums::ObjFlag::CLICKABLE.0,
+            );
+            lv_obj_remove_flag(
+                backdrop_h,
+                crate::enums::ObjFlag::SCROLLABLE.0,
+            );
+        }
+
         boxed
-            .create(&layer_top)
+            .create(&backdrop)
             .expect("modal view create failed");
-        // For modals, register_events default would register on
-        // lv_screen_active() which is the background view's screen.
-        // Modal views should override register_events to register on
-        // the layer_top container instead, or use EVENT_BUBBLE.
-        // We call register_events() and trust the view's override.
-        boxed.register_events();
+        // register_events_on defaults to attaching the trampoline on the
+        // backdrop, so bubbled events from any modal widget reach the
+        // view's on_event. Modal views that catch events on intermediate
+        // widgets can still override register_events_on.
+        boxed.register_events_on(&backdrop);
         boxed.did_show();
+
+        // If the modal exposes a focus group, snapshot the current focus
+        // state and route input to the modal's group. Restored on dismiss.
+        if let Some(modal_group) = boxed.input_group() {
+            self.saved_focus = Some(SavedFocus::capture());
+            modal_group.set_default();
+            modal_group.assign_to_keyboard_indevs();
+        }
+
         self.modal = Some(boxed);
+        self.modal_backdrop = Some(backdrop);
     }
 
     /// Dismiss the current modal overlay.
     ///
-    /// Cleans `lv_layer_top()` children. Returns `Err` if no modal is active.
+    /// Deletes the backdrop (which cascades to the modal's widget tree)
+    /// and restores any focus state captured on open. Returns `Err` if
+    /// no modal is active.
     pub fn dismiss_modal(&mut self) -> Result<(), NavigationError> {
-        if let Some(mut modal) = self.modal.take() {
-            modal.will_hide();
-            // SAFETY: lv_layer_top() returns the global overlay object (valid
-            // after lv_init). lv_obj_clean deletes all children. Any Obj
-            // wrappers in the modal view now hold stale pointers — their Drop
-            // uses lv_obj_is_valid() as a guard (spec-memory-lifetime §8.1).
-            // We clean before dropping the modal so LVGL removes its widgets
-            // from the display immediately.
-            let layer = unsafe { lv_layer_top() };
-            unsafe { lv_obj_clean(layer) };
-            // modal is dropped here — Obj::drop guards prevent double-free.
-            Ok(())
-        } else {
-            Err(NavigationError::NoActiveModal)
+        let mut modal = match self.modal.take() {
+            Some(m) => m,
+            None => return Err(NavigationError::NoActiveModal),
+        };
+        modal.will_hide();
+        // Drop the backdrop Obj — lv_obj_delete cascades to all descendants
+        // (the modal's widget tree). Any Obj wrappers held inside the
+        // modal view now hold stale pointers; their Drop uses
+        // lv_obj_is_valid as a guard (spec-memory-lifetime §8.1).
+        drop(self.modal_backdrop.take());
+        drop(modal);
+
+        // Restore the pre-modal focus state, if we captured it.
+        if let Some(saved) = self.saved_focus.take() {
+            saved.restore();
         }
+        Ok(())
     }
 
     /// Whether a modal is currently showing.
@@ -538,6 +594,64 @@ impl Navigator {
 impl Default for Navigator {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Snapshot of the input-focus state captured when a modal with an
+/// [`input_group`](crate::view::View::input_group) opens. Restored on
+/// dismiss so the background view regains its key/encoder input routing.
+///
+/// Stores raw pointers; we do not own any of these — the groups and
+/// indevs are managed by app or LVGL.
+struct SavedFocus {
+    /// Previous default group (may be NULL).
+    prev_default: *mut lv_group_t,
+    /// Per-indev (KEYPAD/ENCODER) group bindings to restore on dismiss.
+    /// Heap-allocated rather than fixed-size since LVGL allows any
+    /// number of indevs in principle; in practice this is 1–2 entries.
+    prev_indev_groups: Vec<(*mut lv_indev_t, *mut lv_group_t)>,
+}
+
+impl SavedFocus {
+    /// Capture the current default group and per-indev group bindings.
+    fn capture() -> Self {
+        // SAFETY: lv_group_get_default reads a global; safe after lv_init.
+        let prev_default = unsafe { lv_group_get_default() };
+
+        let mut prev_indev_groups = Vec::new();
+        // SAFETY: lv_indev_get_next(NULL) returns the first indev or
+        // NULL. lv_indev_get_type and lv_indev_get_group are safe on
+        // any non-null lv_indev_t.
+        unsafe {
+            let mut indev = lv_indev_get_next(core::ptr::null_mut());
+            while !indev.is_null() {
+                let kind = lv_indev_get_type(indev);
+                if kind == lv_indev_type_t_LV_INDEV_TYPE_KEYPAD
+                    || kind == lv_indev_type_t_LV_INDEV_TYPE_ENCODER
+                {
+                    prev_indev_groups.push((indev, lv_indev_get_group(indev)));
+                }
+                indev = lv_indev_get_next(indev);
+            }
+        }
+
+        Self { prev_default, prev_indev_groups }
+    }
+
+    /// Restore the captured state.
+    fn restore(self) {
+        // SAFETY: pointers were valid when captured. If the previous
+        // default group or any indev has been deleted since (rare,
+        // would imply app-side teardown during a modal), LVGL handles a
+        // NULL/dangling group pointer by routing to no group; we do not
+        // attempt to verify aliveness because LVGL does not expose a
+        // per-group is_valid check.
+        unsafe {
+            lv_group_set_default(self.prev_default);
+            for (indev, group) in self.prev_indev_groups {
+                lv_indev_set_group(indev, group);
+            }
+        }
     }
 }
 

--- a/src/navigator.rs
+++ b/src/navigator.rs
@@ -436,7 +436,7 @@ impl Navigator {
         // its tree is what the view just populated.
         unsafe { remove_clickable_recursive(container_handle) };
 
-        // Intentionally do NOT call boxed.register_events(): the default
+        // Intentionally do NOT call boxed.register_events_on(): the default
         // impl registers on lv_screen_active() (the background view's
         // screen) and would dangle across page switches — exactly the
         // bug this toast surface exists to avoid.

--- a/src/view.rs
+++ b/src/view.rs
@@ -18,7 +18,7 @@ use crate::{
     driver::LvglDriver,
     enums::EventCode,
     event::Event,
-    widgets::{Obj, ScreenAnim, WidgetError},
+    widgets::{AsLvHandle, Obj, ScreenAnim, WidgetError},
 };
 
 /// LVGL timer tick interval (ms). `LV_DEF_REFR_PERIOD / 4` yields ~4 ticks
@@ -43,8 +43,8 @@ const LVGL_TICK_MS: u64 = LV_DEF_REFR_PERIOD as u64 / 4;
 /// set so the event reaches the screen-level handler.
 ///
 /// For nested widget trees (e.g. buttons inside a container), override
-/// [`register_events`](View::register_events) to add event handlers on
-/// intermediate objects via [`register_event_on`].
+/// [`register_events_on`](View::register_events_on) to add event handlers
+/// on intermediate objects via [`register_event_on`].
 pub trait View: Sized + 'static {
     /// Build all LVGL widgets for this view into `container`.
     ///
@@ -68,12 +68,20 @@ pub trait View: Sized + 'static {
         NavAction::None
     }
 
-    /// Register event handlers. Called once after [`create`](View::create).
-    /// Default registers on the active screen only. Override to register on
-    /// additional objects (e.g. containers that catch bubbled events).
-    fn register_events(&mut self) {
-        // SAFETY: lv_screen_active() is valid after lv_init().
-        register_event_on(self, unsafe { lv_screen_active() });
+    /// Register event handlers. Called once after [`create`](View::create),
+    /// with the same `container` that was passed to `create`.
+    ///
+    /// Default registers the view's event trampoline on `container`, so
+    /// bubbled events from any descendant reach [`on_event`](View::on_event).
+    /// Override to register on additional objects (e.g. intermediate
+    /// containers that catch bubbled events for sub-trees).
+    ///
+    /// Receiving the container as an argument — rather than reading
+    /// `lv_screen_active()` — is what makes the default impl correct for
+    /// modals: when the navigator builds a modal, `container` is
+    /// `lv_layer_top()`, not the background view's screen.
+    fn register_events_on(&mut self, container: &Obj<'static>) {
+        register_event_on(self, container.lv_handle());
     }
 
     /// Called before this view's widget tree is destroyed (navigating away).
@@ -83,6 +91,20 @@ pub trait View: Sized + 'static {
     /// Called after this view becomes visible again (navigated back to).
     /// Default is a no-op.
     fn did_show(&mut self) {}
+
+    /// Focus group containing this view's focusable widgets.
+    ///
+    /// When non-`None`, the navigator activates this group on
+    /// modal open (sets it as default + binds it to all keyboard /
+    /// encoder input devices) and restores the previously active focus
+    /// state on dismiss. The view owns the [`Group`](crate::group::Group)
+    /// internally; this method just borrows a non-owning handle.
+    ///
+    /// Default `None` — only OSD-style modals that need key input
+    /// usually return `Some`.
+    fn input_group(&self) -> Option<crate::group::GroupRef> {
+        None
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -165,12 +187,14 @@ pub trait AnyView: 'static {
     fn update(&mut self) -> Result<NavAction, WidgetError>;
     /// Handle a bubbled LVGL event. See [`View::on_event`].
     fn on_event(&mut self, event: &Event) -> NavAction;
-    /// Register event handlers. See [`View::register_events`].
-    fn register_events(&mut self);
+    /// Register event handlers. See [`View::register_events_on`].
+    fn register_events_on(&mut self, container: &Obj<'static>);
     /// Called before widget teardown. See [`View::will_hide`].
     fn will_hide(&mut self);
     /// Called after view becomes visible again. See [`View::did_show`].
     fn did_show(&mut self);
+    /// Focus group for this view (modals only). See [`View::input_group`].
+    fn input_group(&self) -> Option<crate::group::GroupRef>;
 }
 
 impl<T: View> AnyView for T {
@@ -186,8 +210,8 @@ impl<T: View> AnyView for T {
         View::on_event(self, event)
     }
 
-    fn register_events(&mut self) {
-        View::register_events(self)
+    fn register_events_on(&mut self, container: &Obj<'static>) {
+        View::register_events_on(self, container)
     }
 
     fn will_hide(&mut self) {
@@ -196,6 +220,10 @@ impl<T: View> AnyView for T {
 
     fn did_show(&mut self) {
         View::did_show(self)
+    }
+
+    fn input_group(&self) -> Option<crate::group::GroupRef> {
+        View::input_group(self)
     }
 }
 
@@ -251,19 +279,18 @@ pub(crate) fn take_pending_event_action() -> Option<NavAction> {
     unsafe { (*PENDING_EVENT_ACTION.0.get()).take() }
 }
 
-/// Register event handlers for the view. Calls [`View::register_events`],
-/// which by default registers on the active screen. Override the trait method
-/// to register on additional objects.
+/// Register event handlers for the view by delegating to
+/// [`View::register_events_on`] with `container` as the target.
 ///
 /// The `view` reference must remain at a stable address for the lifetime of
 /// the LVGL display (guaranteed by `run_app` and `host_main!`).
-pub fn register_view_events<V: View>(view: &mut V) {
-    view.register_events();
+pub fn register_view_events<V: View>(view: &mut V, container: &Obj<'static>) {
+    view.register_events_on(container);
 }
 
 
 /// Register the view's event trampoline on a specific LVGL object.
-/// Use this from [`View::register_events`] to catch events on containers
+/// Use this from [`View::register_events_on`] to catch events on containers
 /// or other intermediate objects that don't bubble to the screen.
 ///
 /// # Address stability (not enforced by the type system)
@@ -357,7 +384,7 @@ pub async fn run_app<V: View, const BYTES: usize>(
         }
     }
 
-    register_view_events(&mut view);
+    register_view_events(&mut view, &container);
 
     loop {
         debug!("Rendering UI loop iteration");

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -12,6 +12,7 @@ mod draw;
 mod event;
 mod group;
 mod misc;
+mod navigator_modal;
 mod navigator_toast;
 mod obj;
 mod observer;

--- a/tests/integration/navigator_modal.rs
+++ b/tests/integration/navigator_modal.rs
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Tests for the OSD-enablement work on `Navigator::modal`:
+//! - backdrop is created on `lv_layer_top` and is full-size + clickable
+//! - `View::register_events_on` default attaches to the backdrop (not the
+//!   background screen)
+//! - `View::input_group` causes the navigator to push focus into the
+//!   modal's group on open and restore the previous focus on dismiss
+
+use crate::common::ensure_init;
+
+use oxivgl::enums::ObjFlag;
+use oxivgl::group::{Group, group_get_default};
+use oxivgl::navigator::Navigator;
+use oxivgl::view::View;
+use oxivgl::widgets::{AsLvHandle, Button, Obj, WidgetError};
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+#[derive(Default)]
+struct EmptyRoot;
+impl View for EmptyRoot {
+    fn create(&mut self, _container: &Obj<'static>) -> Result<(), WidgetError> {
+        Ok(())
+    }
+}
+
+/// A modal that records, in a static atomic, the LVGL handle of the
+/// container it was registered against.
+mod register_probe {
+    use super::*;
+    use core::sync::atomic::{AtomicUsize, Ordering};
+    pub static REGISTER_TARGET: AtomicUsize = AtomicUsize::new(0);
+
+    #[derive(Default)]
+    pub struct ProbeModal;
+    impl View for ProbeModal {
+        fn create(&mut self, _container: &Obj<'static>) -> Result<(), WidgetError> {
+            Ok(())
+        }
+        fn register_events_on(&mut self, container: &Obj<'static>) {
+            REGISTER_TARGET.store(container.lv_handle() as usize, Ordering::SeqCst);
+            // Don't actually register handlers — we only want the target.
+        }
+    }
+}
+
+/// A modal that owns its own Group and exposes it to the navigator.
+struct GroupModal {
+    group: Group,
+}
+impl GroupModal {
+    fn new() -> Self {
+        Self { group: Group::new().expect("group create") }
+    }
+}
+impl View for GroupModal {
+    fn create(&mut self, container: &Obj<'static>) -> Result<(), WidgetError> {
+        let btn = Button::new(container)?;
+        self.group.add_obj(&btn);
+        Ok(())
+    }
+    fn input_group(&self) -> Option<oxivgl::group::GroupRef> {
+        Some(self.group.as_ref())
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn fresh_navigator() -> Navigator {
+    ensure_init();
+    // Establish an active screen + clean overlay layers so prior tests
+    // don't leak state into this one.
+    unsafe {
+        let new_screen = oxivgl_sys::lv_obj_create(core::ptr::null_mut());
+        oxivgl_sys::lv_screen_load(new_screen);
+        oxivgl_sys::lv_obj_clean(oxivgl_sys::lv_layer_top());
+        oxivgl_sys::lv_obj_clean(oxivgl_sys::lv_layer_sys());
+    }
+    let mut nav = Navigator::new();
+    nav.push_root(EmptyRoot);
+    nav
+}
+
+fn layer_top_child_count() -> u32 {
+    unsafe { oxivgl_sys::lv_obj_get_child_count(oxivgl_sys::lv_layer_top()) }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn modal_creates_clickable_full_size_backdrop_on_layer_top() {
+    let mut nav = fresh_navigator();
+    assert_eq!(layer_top_child_count(), 0);
+
+    nav.modal(EmptyRoot);
+    assert!(nav.has_modal());
+    assert_eq!(
+        layer_top_child_count(),
+        1,
+        "modal should create exactly one direct child (the backdrop)",
+    );
+
+    // SAFETY: layer_top is a valid LVGL global.
+    let backdrop = unsafe {
+        oxivgl_sys::lv_obj_get_child(oxivgl_sys::lv_layer_top(), 0)
+    };
+    assert!(!backdrop.is_null());
+    // Backdrop must be clickable so it absorbs touches; must NOT be scrollable.
+    // SAFETY: backdrop is the live child we just fetched.
+    unsafe {
+        assert!(
+            oxivgl_sys::lv_obj_has_flag(backdrop, ObjFlag::CLICKABLE.0),
+            "backdrop must be CLICKABLE so it absorbs touches",
+        );
+        assert!(
+            !oxivgl_sys::lv_obj_has_flag(backdrop, ObjFlag::SCROLLABLE.0),
+            "backdrop should not be SCROLLABLE",
+        );
+    }
+
+    nav.dismiss_modal().expect("dismiss");
+    assert_eq!(
+        layer_top_child_count(),
+        0,
+        "dismiss must delete the backdrop and any descendants",
+    );
+}
+
+#[test]
+fn modal_default_register_events_targets_the_backdrop_not_active_screen() {
+    use core::sync::atomic::Ordering;
+    register_probe::REGISTER_TARGET.store(0, Ordering::SeqCst);
+
+    let mut nav = fresh_navigator();
+    let background_screen = unsafe { oxivgl_sys::lv_screen_active() as usize };
+
+    nav.modal(register_probe::ProbeModal);
+
+    let recorded = register_probe::REGISTER_TARGET.load(Ordering::SeqCst);
+    assert_ne!(recorded, 0, "register_events_on was not called");
+    assert_ne!(
+        recorded, background_screen,
+        "register_events_on must NOT receive the background screen for a modal — \
+         this was the dangling-handler bug the OSD work is meant to fix",
+    );
+    // The container handed to register_events_on must be the backdrop:
+    // a direct child of lv_layer_top.
+    let backdrop = unsafe {
+        oxivgl_sys::lv_obj_get_child(oxivgl_sys::lv_layer_top(), 0) as usize
+    };
+    assert_eq!(
+        recorded, backdrop,
+        "register_events_on container must be the backdrop, not lv_screen_active()",
+    );
+
+    nav.dismiss_modal().expect("dismiss");
+}
+
+#[test]
+fn modal_with_input_group_swaps_default_group_and_restores_on_dismiss() {
+    let mut nav = fresh_navigator();
+
+    // Set up a "background" default group representing the app's normal
+    // focus group before the modal opens.
+    let app_group = Group::new().expect("app group create");
+    app_group.set_default();
+    let app_group_ptr =
+        group_get_default().expect("default after set_default").add_obj_ptr_for_test();
+
+    nav.modal(GroupModal::new());
+
+    // While the modal is open, the default group must NOT be the app's.
+    let mid_default = group_get_default()
+        .expect("default still set while modal is up")
+        .add_obj_ptr_for_test();
+    assert_ne!(
+        mid_default, app_group_ptr,
+        "navigator must swap the default group to the modal's group on open",
+    );
+
+    nav.dismiss_modal().expect("dismiss");
+
+    // After dismiss, the previous default group must be restored.
+    let restored = group_get_default()
+        .expect("default still set after dismiss")
+        .add_obj_ptr_for_test();
+    assert_eq!(
+        restored, app_group_ptr,
+        "navigator must restore the previous default group on dismiss",
+    );
+}
+
+#[test]
+fn modal_without_input_group_does_not_touch_focus() {
+    let mut nav = fresh_navigator();
+
+    let app_group = Group::new().expect("app group create");
+    app_group.set_default();
+    let before = group_get_default().expect("default").add_obj_ptr_for_test();
+
+    nav.modal(EmptyRoot);
+
+    let during = group_get_default().expect("default").add_obj_ptr_for_test();
+    assert_eq!(
+        during, before,
+        "modal without input_group must not change default group",
+    );
+
+    nav.dismiss_modal().expect("dismiss");
+
+    let after = group_get_default().expect("default").add_obj_ptr_for_test();
+    assert_eq!(after, before, "still unchanged after dismiss");
+}
+
+// ── GroupRef test extension trait ───────────────────────────────────────────
+// GroupRef doesn't expose its raw pointer; for tests we need an identity to
+// compare. Add a sentinel widget and use its address as a stand-in.
+
+trait GroupRefTestExt {
+    /// Return a stable address derived from the group identity, by
+    /// adding a temporary widget and reading its handle back. Two calls
+    /// on the same group return the same address only if both find the
+    /// group still tracking that widget — for test identity comparison
+    /// we use the raw lv_group_get_default pointer via a different route.
+    fn add_obj_ptr_for_test(&self) -> usize;
+}
+
+impl GroupRefTestExt for oxivgl::group::GroupRef {
+    fn add_obj_ptr_for_test(&self) -> usize {
+        // Use the raw lv_group_get_default pointer as identity — both
+        // sides of the comparison query the same global, so as long as
+        // we call this right after observing the default group it is a
+        // sound identity proxy.
+        unsafe { oxivgl_sys::lv_group_get_default() as usize }
+    }
+}


### PR DESCRIPTION
## Summary

**Stacked on top of #91** — base branch is `docs/cr-navigator-global-status-overlay`, not `master`. Merge after #91.

This PR closes the four oxivgl gaps that block first-class **page-specific OSD-style modals** (the future popup menu that takes keyboard / encoder input). All four are needed before an app can put together an OSD without `unsafe` blocks or per-view boilerplate.

## Changes

### 1. `View` trait: `register_events_on(container)` replaces `register_events()`

```rust
// before
fn register_events(&mut self) {
    register_event_on(self, unsafe { lv_screen_active() });
}

// after
fn register_events_on(&mut self, container: &Obj<'static>) {
    register_event_on(self, container.lv_handle());
}
```

The old default read `lv_screen_active()`. For a modal that meant attaching to the **background view's** screen — exactly the dangling-handler bug the original toast CR called out. The new default attaches to the container the navigator passes (screen for full-screen views, backdrop for modals, system layer for toasts) — correct in every case, no per-view override needed.

`AnyView` gets the matching signature. `run_app` / `host_main!` / 35 example files updated mechanically.

### 2. Click-absorbing modal backdrop (actually implemented)

`spec-navigation §4.2` already promised one. `modal_boxed` now builds it: full-size `Obj` child of `lv_layer_top()` with `CLICKABLE` set and `SCROLLABLE` cleared. The modal's widgets are created as children of the backdrop. Dismissal drops the backdrop `Obj` and the cascade deletes the modal — a single root, no more `lv_obj_clean(lv_layer_top())` call.

### 3. Navigator focus push / pop

New trait method:

\`\`\`rust
fn input_group(&self) -> Option<GroupRef> { None }
\`\`\`

When a modal opens and returns \`Some(group)\`:
- snapshot the current default group + per-indev (KEYPAD / ENCODER) bindings into a private \`SavedFocus\`;
- \`group.set_default()\` + \`group.assign_to_keyboard_indevs()\`.

On dismiss, \`SavedFocus\` restores both. Apps never touch \`lv_indev_set_group\` / \`lv_group_set_default\` directly.

### 4. Small group/indev wrapper additions

- \`Group::as_ref() -> GroupRef\` — borrow as non-owning handle.
- \`GroupRef::set_default()\` — mirror of \`Group::set_default\` for non-owning restores.
- \`GroupRef::assign_to_keyboard_indevs()\` — same.

## Files

| File | Change |
|------|--------|
| \`src/view.rs\` | Trait signature change; \`input_group\` added to \`View\` + \`AnyView\` + blanket impl. |
| \`src/navigator.rs\` | Backdrop creation in \`modal_boxed\`; cascade-delete on dismiss; \`SavedFocus\` capture/restore. |
| \`src/group.rs\` | \`Group::as_ref\`, \`GroupRef::set_default\`, \`GroupRef::assign_to_keyboard_indevs\`. |
| \`tests/integration/navigator_modal.rs\` | **new** — 4 tests (see below). |
| \`docs/spec-navigation.md\` | §3 (View trait additions), §4.2 (backdrop, event registration, focus push/pop). |
| \`examples/**/*.rs\` (35 files) | Mechanical rename: \`fn register_events\` → \`fn register_events_on(_, _container)\`. |

## Tests

\`tests/integration/navigator_modal.rs\` — 4 tests:

1. **\`modal_creates_clickable_full_size_backdrop_on_layer_top\`** — exactly one child on \`lv_layer_top()\`, \`CLICKABLE\` set, \`SCROLLABLE\` cleared, gone after dismiss.
2. **\`modal_default_register_events_targets_the_backdrop_not_active_screen\`** — regression test for the dangling-handler bug: the container passed to \`register_events_on\` must equal the backdrop, must **not** equal \`lv_screen_active()\`.
3. **\`modal_with_input_group_swaps_default_group_and_restores_on_dismiss\`** — focus is hijacked on open, restored on dismiss.
4. **\`modal_without_input_group_does_not_touch_focus\`** — confirms the navigator only swaps when the modal opts in.

## Test plan

- [x] \`cargo check\` (host) — clean.
- [x] \`cargo +esp -Zbuild-std=alloc,core check --release --target xtensa-esp32-none-elf --features esp-hal,esp32,log-04\` — clean.
- [x] \`./run_tests.sh unit\` — 36 passed.
- [x] \`./run_tests.sh int\` — 499 passed (4 new modal tests).
- [x] \`./run_tests.sh leak\` — 63 passed (no regression from modal-backdrop refactor).
- [x] \`cargo doc -W missing-docs\` — 0 warnings.

## Notes

- **Breaking change**: \`View::register_events\` → \`register_events_on(container)\`. Justified by the bug fix it enables; crate is 0.1.x and all in-repo examples were migrated as part of this commit.
- The toast feature (#91) is **untouched** — toasts are still on \`lv_layer_sys()\`, still passive, still skip \`register_events_on\` entirely.
- Apps written against \`register_events()\` need a one-line method-signature update (the bodies typically don't need to change — they ignore the new \`_container\` arg or use it as the registration target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)