### PR TITLE
feat: post_toast / post_dismiss_toast — raise toasts from any task

### DIFF
--- a/docs/spec-navigation.md
+++ b/docs/spec-navigation.md
@@ -414,6 +414,39 @@ a third-party clear of the system layer), `tick_toast` detects the
 stale handle via `lv_obj_is_valid` and drops the orphaned view so the
 slot becomes reusable.
 
+**Raising from any task.** Background async tasks that hold no
+`Navigator` handle (BLE listener, sensor poller, app shell at boot
+before any view is on screen) can still raise toasts via two free
+functions:
+
+```rust
+pub fn post_toast<V: View + Send>(view: V, duration: Option<Duration>);
+pub fn post_dismiss_toast();
+```
+
+Both enqueue into a library-owned static `Channel`
+(capacity `TOAST_QUEUE_CAPACITY = 4`, `CriticalSectionRawMutex`).
+`run_app_nav` calls `nav.drain_toast_requests()` once per render-loop
+iteration before `tick_toast`. The drained request flows through the
+same `show_toast_boxed` / `dismiss_toast` paths as `NavAction::ShowToast`
+— so all the passivity / persistence / auto-dismiss guarantees apply
+identically; only the initiator differs.
+
+The `Send` bound on the View type rules out keeping live `Obj` wrappers
+in toast struct fields (raw pointers are `!Send`). In practice this is
+not a constraint — toast views are typically simple config structs
+(text, color, icon source) that build their widgets inside
+`View::create` from the supplied `&Obj<'static>` container; the widgets
+then live as children of the toast container, owned by LVGL.
+
+If the queue is full when `post_toast` runs, the new request is dropped
+with a logged warning rather than blocking — toasts are notifications,
+not data; a dropped duplicate is preferable to async deadlock.
+
+This closes the "no draining view" gap: a "No SD card" warning raised
+at boot from an SD-card task no longer needs the currently-active view
+to opt into draining a status channel.
+
 **Distinction from `Modal`.**
 
 | Property               | `Modal`                              | Toast                          |

--- a/src/navigator.rs
+++ b/src/navigator.rs
@@ -15,6 +15,7 @@ extern crate alloc;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, channel::Channel};
 use embassy_time::Duration;
 use oxivgl_sys::*;
 
@@ -589,11 +590,99 @@ impl Navigator {
             false
         }
     }
+
+    /// Drain any toast requests posted from background tasks via
+    /// [`post_toast`] / [`post_dismiss_toast`].
+    ///
+    /// Called once per render-loop iteration by `run_app_nav`. Each
+    /// queued request becomes a `show_toast` or `dismiss_toast` call.
+    pub fn drain_toast_requests(&mut self) {
+        while let Ok(req) = TOAST_CHANNEL.try_receive() {
+            match req {
+                ToastRequest::Show(view, duration) => {
+                    // Box<dyn AnyView + Send> coerces to Box<dyn AnyView>
+                    // via unsizing — Send is dropped from the trait object.
+                    self.show_toast_boxed(view, duration);
+                }
+                ToastRequest::Dismiss => {
+                    let _ = self.dismiss_toast();
+                }
+            }
+        }
+    }
 }
 
 impl Default for Navigator {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Cross-task toast posting (TOAST_CHANNEL + post_toast / post_dismiss_toast)
+// ---------------------------------------------------------------------------
+
+/// Capacity of the global toast request queue. Toasts are infrequent;
+/// 4 outstanding requests tolerate brief contention without backpressure.
+const TOAST_QUEUE_CAPACITY: usize = 4;
+
+/// A request enqueued by [`post_toast`] / [`post_dismiss_toast`] and
+/// drained by [`Navigator::drain_toast_requests`].
+enum ToastRequest {
+    Show(Box<dyn AnyView + Send>, Option<Duration>),
+    Dismiss,
+}
+
+/// Global queue of toast requests. Posted to from any async task,
+/// drained by the render loop via [`Navigator::drain_toast_requests`].
+static TOAST_CHANNEL: Channel<CriticalSectionRawMutex, ToastRequest, TOAST_QUEUE_CAPACITY> =
+    Channel::new();
+
+/// Queue a global passive toast from **any** async task — including
+/// background workers that hold no `Navigator` handle.
+///
+/// The request is processed on the next render-loop iteration
+/// (`run_app_nav` calls [`Navigator::drain_toast_requests`] every
+/// tick). It then flows through the same path as
+/// [`Navigator::show_toast`], so all the passivity / persistence /
+/// auto-dismiss guarantees apply identically — the only difference is
+/// who initiated it.
+///
+/// Use this for **truly global status messages** (e.g. "No SD card",
+/// "BLE disconnected") raised before any particular view is on screen
+/// or from a task that has no reason to know about the active view.
+///
+/// # `View: Send` constraint
+///
+/// The view crosses a `Channel` boundary, so its concrete type must be
+/// `Send`. In practice toast views are simple config structs (text,
+/// color, icon source) — they don't store live `Obj` wrappers, which
+/// are `!Send`. Build the actual widgets inside `View::create` from
+/// `&Obj<'static>` parameters; do **not** keep them in struct fields.
+///
+/// # Backpressure
+///
+/// The queue holds 4 outstanding requests (`TOAST_QUEUE_CAPACITY`).
+/// If full, this call logs a warning and drops the request rather than
+/// blocking — toasts are notifications, not data; a dropped duplicate
+/// is preferable to async deadlock.
+pub fn post_toast<V: View + Send>(view: V, duration: Option<Duration>) {
+    let req = ToastRequest::Show(Box::new(view), duration);
+    if TOAST_CHANNEL.try_send(req).is_err() {
+        warn!("post_toast: queue full ({}), request dropped", TOAST_QUEUE_CAPACITY);
+    }
+}
+
+/// Queue a request to dismiss the active toast from any async task.
+///
+/// Same delivery semantics as [`post_toast`]. No-op on the render-loop
+/// side if no toast is active when the request is processed.
+pub fn post_dismiss_toast() {
+    if TOAST_CHANNEL.try_send(ToastRequest::Dismiss).is_err() {
+        warn!(
+            "post_dismiss_toast: queue full ({}), request dropped",
+            TOAST_QUEUE_CAPACITY,
+        );
     }
 }
 

--- a/src/view.rs
+++ b/src/view.rs
@@ -471,6 +471,10 @@ pub async fn run_app_nav<const BYTES: usize>(
             }
         }
 
+        // Drain toast requests posted from background tasks via
+        // navigator::post_toast / post_dismiss_toast.
+        nav.drain_toast_requests();
+
         // Auto-dismiss expired toasts; self-heal if the slot was orphaned.
         nav.tick_toast();
     }

--- a/tests/integration/navigator_toast.rs
+++ b/tests/integration/navigator_toast.rs
@@ -188,3 +188,77 @@ fn input_transparency_strips_clickable() {
 
     nav.dismiss_toast().expect("dismiss");
 }
+
+// ── post_toast / post_dismiss_toast (cross-task queue) ──────────────────────
+
+#[test]
+fn post_toast_then_drain_shows_toast() {
+    let mut nav = fresh_navigator();
+    assert!(!nav.has_toast());
+
+    // Post from "elsewhere" — same task here, but the channel path is
+    // identical to a real cross-task post.
+    oxivgl::navigator::post_toast(LabelToast, None);
+    assert!(!nav.has_toast(), "post must not bypass the drain step");
+
+    nav.drain_toast_requests();
+    assert!(nav.has_toast(), "drain_toast_requests should pick up the queued show");
+    assert_eq!(sys_layer_child_count(), 1);
+
+    nav.dismiss_toast().expect("dismiss");
+}
+
+#[test]
+fn post_dismiss_toast_then_drain_dismisses() {
+    let mut nav = fresh_navigator();
+    nav.show_toast(LabelToast, None);
+    assert!(nav.has_toast());
+
+    oxivgl::navigator::post_dismiss_toast();
+    nav.drain_toast_requests();
+    assert!(!nav.has_toast());
+    assert_eq!(sys_layer_child_count(), 0);
+}
+
+#[test]
+fn multiple_posts_in_one_drain_collapse_to_latest() {
+    let mut nav = fresh_navigator();
+    // Three queued shows + one dismiss: the navigator processes them
+    // in order; show→show replaces, then show, then dismiss. End state:
+    // no toast.
+    oxivgl::navigator::post_toast(LabelToast, None);
+    oxivgl::navigator::post_toast(LabelToast, None);
+    oxivgl::navigator::post_toast(LabelToast, None);
+    oxivgl::navigator::post_dismiss_toast();
+
+    nav.drain_toast_requests();
+    assert!(!nav.has_toast());
+    assert_eq!(sys_layer_child_count(), 0);
+}
+
+#[test]
+fn drain_with_empty_queue_is_a_noop() {
+    let mut nav = fresh_navigator();
+    nav.drain_toast_requests();
+    nav.drain_toast_requests();
+    assert!(!nav.has_toast());
+}
+
+#[test]
+fn post_toast_queue_full_drops_silently() {
+    // Drain anything left over from prior tests in the queue.
+    let mut nav = fresh_navigator();
+    nav.drain_toast_requests();
+
+    // Fill the queue (capacity 4 today). Posting more must not panic
+    // or block — excess requests are dropped with a logged warning.
+    for _ in 0..16 {
+        oxivgl::navigator::post_toast(LabelToast, None);
+    }
+    nav.drain_toast_requests();
+    // We can't assert exactly how many were dropped (it depends on the
+    // queue capacity constant), but draining must leave us in a sane
+    // state and the next dismiss must succeed.
+    assert!(nav.has_toast());
+    nav.dismiss_toast().expect("dismiss after queue-overflow recovery");
+}


### PR DESCRIPTION
## Summary

**Stacked on #92** (base: `feature/navigator-osd-enablement`). Closes the *"no draining view"* gap explicitly noted as out-of-scope in #91.

> _The user reported: "we had that problem with missing toasts in the app before"._

The original toast feature shipped in #91 fixed *persistence*, *passivity*, and *lifetime* — but raising a toast still required some currently-active `View` to drain an app-owned channel and return `NavAction::ShowToast`. That fails the *original* alternator-regulator scenario: a "No SD card" warning raised by an SD-card task at boot doesn't appear if the root view doesn't know about that channel.

## API

Two new free functions in `oxivgl::navigator`:

\`\`\`rust
pub fn post_toast<V: View + Send>(view: V, duration: Option<Duration>);
pub fn post_dismiss_toast();
\`\`\`

Both enqueue into a library-owned static `Channel<CriticalSectionRawMutex, ToastRequest, 4>`. `run_app_nav` calls the new `Navigator::drain_toast_requests()` once per loop iteration (before `tick_toast`). Drained requests flow through the same `show_toast_boxed` / `dismiss_toast` paths as `NavAction::ShowToast` — identical passivity / persistence / auto-dismiss semantics.

## Design notes

- **`View: Send` bound** — required because the View crosses a `Channel` boundary. In practice toast views are simple config structs (text, color, icon source) that build their widgets inside `View::create` from the supplied `&Obj<'static>`; live `Obj` wrappers are `!Send` and shouldn't be stored in toast struct fields anyway.
- **Capacity 4** — toasts are infrequent; if full, `post_toast` logs a warn and drops the request rather than blocking. Toasts are notifications, not data — async deadlock would be worse than a dropped duplicate.
- **Purely additive** — `NavAction::ShowToast` and `Navigator::show_toast` remain unchanged for view-driven toasts.

## Files

| File | Change |
|------|--------|
| `src/navigator.rs` | Static `TOAST_CHANNEL` + `ToastRequest` enum; `post_toast` / `post_dismiss_toast` free fns; `Navigator::drain_toast_requests`. |
| `src/view.rs` | `run_app_nav` calls `nav.drain_toast_requests()` each iteration before `tick_toast`. |
| `tests/integration/navigator_toast.rs` | 5 new tests (see below). |
| `docs/spec-navigation.md` | §4.3 gains a "Raising from any task" subsection. |

## Tests

5 new tests appended to `tests/integration/navigator_toast.rs`:

1. `post_toast_then_drain_shows_toast` — post-then-drain ends in `has_toast() == true`.
2. `post_dismiss_toast_then_drain_dismisses` — dismiss path mirror.
3. `multiple_posts_in_one_drain_collapse_to_latest` — show → show → show → dismiss in one drain ends with no toast.
4. `drain_with_empty_queue_is_a_noop` — no panic, no state change.
5. `post_toast_queue_full_drops_silently` — 16 posts against a 4-slot queue do not panic; navigator recovers.

## Test plan

- [x] `cargo check` (host) — clean.
- [x] `cargo +esp -Zbuild-std=alloc,core build --release --target xtensa-esp32-none-elf --example getting_started1` — clean (the failure mode that bit #92 was a macro-expansion path; example builds catch it).
- [x] `./run_tests.sh int` — 504 passed (5 new tests).
- [x] `./run_tests.sh leak` — 63 passed.
- [x] `cargo doc -W missing-docs` — 0 warnings.

## Notes

- No breaking changes — purely additive.
- The base branch is `feature/navigator-osd-enablement` (PR #92). Once #92 lands, GitHub will auto-retarget this to `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)