### PR TITLE
chore: prepare v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] — 2026-05-31
+
+### Added
+
+- **Global passive toast overlay.** `Navigator::show_toast` / `dismiss_toast` /
+  `tick_toast`; `NavAction::{ShowToast, DismissToast}`. Lives on `lv_layer_sys()`,
+  persists across push/replace/pop, input-transparent by contract,
+  navigator-owned auto-dismiss.
+- **Post toasts from any task.** Free functions `post_toast<V: View + Send>` and
+  `post_dismiss_toast` enqueue into a library-owned channel drained by
+  `run_app_nav` — no draining view required.
+- **OSD-style modal support.** Click-absorbing backdrop on `lv_layer_top()`
+  (was specified, now implemented). `View::input_group() -> Option<GroupRef>`:
+  when `Some`, the navigator swaps focus into the modal's group on open and
+  restores the previous default group + per-indev bindings on dismiss.
+- `Group::as_ref`, `GroupRef::set_default`, `GroupRef::assign_to_keyboard_indevs`.
+
+### Changed
+
+- **Breaking:** `View::register_events(&mut self)` renamed to
+  `register_events_on(&mut self, container: &Obj<'static>)`. The default attaches
+  the trampoline to `container` (the navigator-supplied target) rather than
+  `lv_screen_active()`.
+
+  *Migration:* rename the override and add the `_container` parameter; bodies
+  typically don't need to change. Overrides that just called the old default can
+  be deleted — the new default is correct for screens and modals alike.
+
+### Fixed
+
+- Modal `register_events` no longer attaches handlers to the *background view's*
+  screen (where they dangled after the next push/pop). The new
+  `register_events_on(container)` default routes correctly for every overlay.
+
 ## [0.1.2] — 2026-05-06
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "oxivgl"
 edition = "2024"
-version = "0.1.2"
+version = "0.2.0"
 license = "MIT OR Apache-2.0"
 description = "Safe no_std Rust bindings for LVGL — embedded GUI on ESP32 and host SDL2"
 repository = "https://github.com/emobotics-dev/oxivgl"
@@ -38,7 +38,7 @@ log-04 = ["dep:log-04"]
 png = ["dep:png"]
 
 [dependencies]
-oxivgl_sys = { package = "oxivgl-sys", version = "0.1.2", path = "oxivgl-sys", default-features = false }
+oxivgl_sys = { package = "oxivgl-sys", version = "0.2.0", path = "oxivgl-sys", default-features = false }
 embassy-sync = "0.8"
 embassy-time = "0.5.0"
 heapless = { version = "0.9.1", features = ["nightly"] }
@@ -58,7 +58,7 @@ exclude = ["examples/common", "oxivgl-build", "oxivgl-sys"]
 
 [dev-dependencies]
 oxivgl-examples-common = { path = "examples/common" }
-oxivgl_sys = { package = "oxivgl-sys", version = "0.1.2", path = "oxivgl-sys", default-features = false }
+oxivgl_sys = { package = "oxivgl-sys", version = "0.2.0", path = "oxivgl-sys", default-features = false }
 
 # Proc-macro crates needed by fire27_main! attribute/macro expansion on xtensa
 [target.'cfg(target_arch = "xtensa")'.dev-dependencies]

--- a/oxivgl-sys/Cargo.toml
+++ b/oxivgl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxivgl-sys"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Raw LVGL v9.5 FFI bindings for oxivgl — compiled from source with bindgen"


### PR DESCRIPTION
## Summary

**Stacked on #93.** Bumps oxivgl + oxivgl-sys to **0.2.0** and adds a CHANGELOG entry covering the navigator-overlay work shipped via #91 (toast), #92 (OSD enablement), and #93 (post_toast).

Minor bump under 0.x SemVer: the \`View::register_events\` → \`register_events_on\` rename in #92 is breaking, so 0.1.x → 0.2.0.

## Files

- \`Cargo.toml\` — \`version = "0.2.0"\` + intra-workspace \`oxivgl-sys\` dep refs.
- \`oxivgl-sys/Cargo.toml\` — \`version = "0.2.0"\`.
- \`CHANGELOG.md\` — new \`[0.2.0]\` section with the three new features and the breaking trait rename, plus a migration note.

## Verification

- [x] \`cargo check\` (host) — clean.
- [x] \`./run_tests.sh int\` — 504 passed.
- [x] \`cargo doc -W missing-docs\` — 0 warnings.
- [x] \`DOCS_RS=1 cargo publish --dry-run -p oxivgl-sys\` — clean. (\`oxivgl\` dry-run cannot succeed until \`oxivgl-sys\` is on crates.io; this is normal.)

## Publish flow (after merge)

\`\`\`sh
# 1. Publish the sys crate.
cargo publish -p oxivgl-sys

# 2. Wait for crates.io indexing (~1 minute).

# 3. Publish the main crate.
cargo publish -p oxivgl

# 4. Tag.
git tag -a v0.2.0 -m "Release v0.2.0"
git push origin v0.2.0
\`\`\`

(See \`reference_crates_io_publishing.md\` notes for 403 troubleshooting, env-var vs file tokens, and the docs.rs no-network workaround already in place.)

## Notes

- Base is \`feature/navigator-toast-from-anywhere\` (PR #93). Once #92 and #93 land, GitHub auto-retargets this to \`master\`.
- The CHANGELOG entry intentionally omits drive-by and docs-only changes per project convention — those live in commit messages and the spec, not the user-facing changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)