### PR TITLE
feat(navigator): default toast geometry + v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] — 2026-05-31
+
+### Added
+
+- **Default toast geometry.** `show_toast` now positions the container
+  as a bottom-anchored floating card — full sys-layer width, symmetric
+  `TOAST_MARGIN_PX` (2 px) inset on left / right / bottom, height
+  hugging content. Views may still override on the container in
+  `create`. New public `navigator::TOAST_MARGIN_PX`.
+
 ## [0.2.0] — 2026-05-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Default toast geometry.** `show_toast` now positions the container
-  as a bottom-anchored floating card — full sys-layer width, symmetric
-  `TOAST_MARGIN_PX` (2 px) inset on left / right / bottom, height
-  hugging content. Views may still override on the container in
-  `create`. New public `navigator::TOAST_MARGIN_PX`.
+- **Default toast geometry and shadow.** `show_toast` now positions
+  the container as a bottom-anchored floating card — full sys-layer
+  width, symmetric `TOAST_MARGIN_PX` (2 px) inset on left / right /
+  bottom, height hugging content, plus a soft symmetric shadow
+  (`TOAST_SHADOW_WIDTH_PX = 12`, `TOAST_SHADOW_OPA = 80`) to reinforce
+  the elevated look. Views may still override on the container in
+  `create`. New public constants in `navigator`.
 
 ## [0.2.0] — 2026-05-31
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "oxivgl"
 edition = "2024"
-version = "0.2.0"
+version = "0.2.1"
 license = "MIT OR Apache-2.0"
 description = "Safe no_std Rust bindings for LVGL — embedded GUI on ESP32 and host SDL2"
 repository = "https://github.com/emobotics-dev/oxivgl"
@@ -38,7 +38,7 @@ log-04 = ["dep:log-04"]
 png = ["dep:png"]
 
 [dependencies]
-oxivgl_sys = { package = "oxivgl-sys", version = "0.2.0", path = "oxivgl-sys", default-features = false }
+oxivgl_sys = { package = "oxivgl-sys", version = "0.2.1", path = "oxivgl-sys", default-features = false }
 embassy-sync = "0.8"
 embassy-time = "0.5.0"
 heapless = { version = "0.9.1", features = ["nightly"] }
@@ -58,7 +58,7 @@ exclude = ["examples/common", "oxivgl-build", "oxivgl-sys"]
 
 [dev-dependencies]
 oxivgl-examples-common = { path = "examples/common" }
-oxivgl_sys = { package = "oxivgl-sys", version = "0.2.0", path = "oxivgl-sys", default-features = false }
+oxivgl_sys = { package = "oxivgl-sys", version = "0.2.1", path = "oxivgl-sys", default-features = false }
 
 # Proc-macro crates needed by fire27_main! attribute/macro expansion on xtensa
 [target.'cfg(target_arch = "xtensa")'.dev-dependencies]

--- a/oxivgl-sys/Cargo.toml
+++ b/oxivgl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxivgl-sys"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Raw LVGL v9.5 FFI bindings for oxivgl — compiled from source with bindgen"

--- a/src/navigator.rs
+++ b/src/navigator.rs
@@ -27,6 +27,13 @@ use crate::view::{
 };
 use crate::widgets::{AsLvHandle, Obj, Screen, ScreenAnim};
 
+/// Symmetric inset (in pixels) applied to the default toast container
+/// on left, right, and bottom — gives the toast a "floating card" look
+/// by leaving a uniform sliver of the underlying view visible on all
+/// three free sides. Override by re-setting size / alignment / margin
+/// on the container inside [`View::create`].
+pub const TOAST_MARGIN_PX: i32 = 2;
+
 /// Entry on the navigation stack, pairing a type-erased view with its
 /// owning screen object (if any).
 struct ViewEntry {
@@ -398,6 +405,16 @@ impl Navigator {
     ///   next time [`tick_toast`](Self::tick_toast) runs after the
     ///   deadline. `None` means the caller must dismiss explicitly.
     ///
+    /// # Default geometry
+    ///
+    /// Before [`View::create`] runs, the container is sized and
+    /// positioned for a bottom-anchored "floating card": full sys-layer
+    /// width with a symmetric [`TOAST_MARGIN_PX`]-pixel inset on left
+    /// and right, height hugging its content, anchored at
+    /// `Align::BottomMid` lifted by the same margin. The view can
+    /// override any of this by re-setting size, alignment, or styles
+    /// on the container inside `create`.
+    ///
     /// Calling `show_toast` while one is already active replaces it.
     pub fn show_toast(&mut self, view: impl View, duration: Option<Duration>) {
         self.show_toast_boxed(Box::new(view), duration);
@@ -422,6 +439,23 @@ impl Navigator {
         let container_handle = unsafe { lv_obj_create(sys_layer) };
         assert!(!container_handle.is_null(), "toast container creation failed");
         let container = Obj::from_raw(container_handle);
+
+        // Default geometry: bottom-anchored floating card with a
+        // symmetric margin on left / right / bottom. Applied BEFORE
+        // create() so a custom view can override on the same container.
+        // SAFETY: container_handle is the freshly-created object above.
+        unsafe {
+            lv_obj_set_width(container_handle, lv_pct(100));
+            lv_obj_set_style_margin_left(container_handle, TOAST_MARGIN_PX, 0);
+            lv_obj_set_style_margin_right(container_handle, TOAST_MARGIN_PX, 0);
+            lv_obj_set_height(container_handle, crate::style::LV_SIZE_CONTENT);
+            lv_obj_align(
+                container_handle,
+                lv_align_t_LV_ALIGN_BOTTOM_MID as lv_align_t,
+                0,
+                -TOAST_MARGIN_PX,
+            );
+        }
 
         if let Err(e) = boxed.create(&container) {
             warn!("nav show_toast: create failed: {:?}", e);

--- a/src/navigator.rs
+++ b/src/navigator.rs
@@ -34,6 +34,13 @@ use crate::widgets::{AsLvHandle, Obj, Screen, ScreenAnim};
 /// on the container inside [`View::create`].
 pub const TOAST_MARGIN_PX: i32 = 2;
 
+/// Default shadow blur radius (px) for the toast container. Together
+/// with [`TOAST_SHADOW_OPA`], gives the toast a soft elevated halo.
+pub const TOAST_SHADOW_WIDTH_PX: i32 = 12;
+
+/// Default shadow opacity (0..=255) for the toast container.
+pub const TOAST_SHADOW_OPA: u8 = 80;
+
 /// Entry on the navigation stack, pairing a type-erased view with its
 /// owning screen object (if any).
 struct ViewEntry {
@@ -455,6 +462,9 @@ impl Navigator {
                 0,
                 -TOAST_MARGIN_PX,
             );
+            // Soft symmetric halo — reinforces the "elevated card" look.
+            lv_obj_set_style_shadow_width(container_handle, TOAST_SHADOW_WIDTH_PX, 0);
+            lv_obj_set_style_shadow_opa(container_handle, TOAST_SHADOW_OPA, 0);
         }
 
         if let Err(e) = boxed.create(&container) {


### PR DESCRIPTION
## Summary

- Toasts now ship with sensible default geometry: bottom-anchored floating card, full sys-layer width with a symmetric **2 px** inset on left / right / bottom, height hugging content.
- Replaces LVGL's default (a 100×50 box pinned to the top-left), which was almost never what an app wanted for a status popup.
- Defaults are applied **before** \`View::create\`, so a custom toast view can still override size, alignment, or margin on the container it receives.
- Bumps to **v0.2.1** (additive — toasts are brand new in v0.2.0, no deployed custom styling to break).

New public item: \`navigator::TOAST_MARGIN_PX\` (2).

## Test plan

- [x] \`cargo check\` (host, default features)
- [x] \`cargo +esp -Zbuild-std=alloc,core check --target xtensa-esp32-none-elf --features esp-hal,esp32,log-04\`
- [x] \`./run_tests.sh unit\` — 36 doc tests pass
- [x] \`./run_tests.sh int\` — 504 integration tests pass (existing toast tests adapt to new geometry without changes)
- [x] \`./run_tests.sh leak\` — 63 leak tests pass (including \`leak_navigator_toast_show_dismiss\`)
- [x] \`RUSTDOCFLAGS="-W missing-docs" cargo doc --no-deps\` — 0 warnings

## Publishing (after merge)

\`\`\`sh
cargo publish -p oxivgl-sys     # publish sys first; wait for crates.io indexing (~30s)
cargo publish -p oxivgl
git tag v0.2.1 && git push origin v0.2.1
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)