### PR TITLE
refactor: take core::time::Duration for toast timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] — 2026-06-03
+
+### Changed
+
+- **Toast timeout type is now `core::time::Duration`** instead of
+  `embassy_time::Duration`. The value was always collapsed to a `u32`
+  millisecond count internally, so the `embassy_time` type was pure ceremony
+  that forced every consumer of a *timed* toast to add an `embassy-time`
+  dependency. Affected public API: `Navigator::show_toast`,
+  `navigator::post_toast`, and `NavAction::ShowToast` / `NavAction::show_toast`.
+  Callers now write `Some(Duration::from_secs(3))` with the dependency-free,
+  no_std `core` type. `embassy-time` remains an internal dependency (render-loop
+  timers, tick source) but no longer appears in the public toast signature.
+
 ## [0.3.1] — 2026-06-03
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "oxivgl"
 edition = "2024"
-version = "0.3.1"
+version = "0.3.2"
 license = "MIT OR Apache-2.0"
 description = "Safe no_std Rust bindings for LVGL — embedded GUI on ESP32 and host SDL2"
 repository = "https://github.com/emobotics-dev/oxivgl"

--- a/src/navigator.rs
+++ b/src/navigator.rs
@@ -17,7 +17,7 @@ use alloc::collections::VecDeque;
 use alloc::vec::Vec;
 
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, channel::Channel};
-use embassy_time::Duration;
+use core::time::Duration;
 use oxivgl_sys::*;
 
 use crate::driver::get_tick_ms;
@@ -588,11 +588,11 @@ impl Navigator {
         self.toast = Some(boxed);
         self.toast_container = Some(container);
         self.toast_deadline_ms = duration.map(|d| {
-            // Saturate the embassy Duration into u32 ms (≈49.7 days max),
-            // then wrap-add to the current tick. The compare in tick_toast
-            // uses `wrapping_sub` so wrap-around is correct as long as the
+            // Saturate the Duration into u32 ms (≈49.7 days max), then
+            // wrap-add to the current tick. The compare in tick_toast uses
+            // `wrapping_sub` so wrap-around is correct as long as the
             // duration is < ~25 days.
-            let ms = d.as_millis().min(u32::MAX as u64) as u32;
+            let ms = d.as_millis().min(u32::MAX as u128) as u32;
             get_tick_ms().wrapping_add(ms)
         });
         true

--- a/src/view.rs
+++ b/src/view.rs
@@ -9,7 +9,8 @@ use alloc::boxed::Box;
 use core::cell::UnsafeCell;
 use core::ffi::c_void;
 
-use embassy_time::{Duration, Timer};
+use core::time::Duration;
+use embassy_time::Timer;
 
 use oxivgl_sys::*;
 
@@ -380,7 +381,7 @@ pub async fn run_app<V: View, const BYTES: usize>(
     if let Err(e) = view.create(&container) {
         warn!("Could not create LVGL widgets: {:?}, disabling UI", e);
         loop {
-            Timer::after(Duration::from_secs(60)).await;
+            Timer::after(embassy_time::Duration::from_secs(60)).await;
         }
     }
 
@@ -397,7 +398,7 @@ pub async fn run_app<V: View, const BYTES: usize>(
         for _ in 0..4 {
             debug!("LVGL tick/timer handler");
             driver.timer_handler();
-            Timer::after(Duration::from_millis(LVGL_TICK_MS)).await;
+            Timer::after(embassy_time::Duration::from_millis(LVGL_TICK_MS)).await;
         }
 
         // Drain any pending event action (stashed by on_event trampoline).
@@ -553,7 +554,7 @@ where
         for _ in 0..4 {
             driver.timer_handler();
             match embassy_time::with_timeout(
-                Duration::from_millis(LVGL_TICK_MS),
+                embassy_time::Duration::from_millis(LVGL_TICK_MS),
                 wake(),
             )
             .await

--- a/tests/integration/navigator_toast.rs
+++ b/tests/integration/navigator_toast.rs
@@ -5,7 +5,7 @@ use crate::common::{ensure_init, pump};
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use embassy_time::Duration;
+use std::time::Duration;
 use oxivgl::enums::ObjFlag;
 use oxivgl::navigator::Navigator;
 use oxivgl::view::{NavigationError, View};


### PR DESCRIPTION
## What

Switch the public toast-timeout parameter from `embassy_time::Duration` to the dependency-free, no_std **`core::time::Duration`**.

Affected public API:
- `Navigator::show_toast`
- `navigator::post_toast`
- `NavAction::ShowToast` / `NavAction::show_toast`

## Why

The timeout value was always collapsed to a `u32` millisecond count internally (`navigator.rs`), so `embassy_time::Duration` was pure ceremony in this API — it never reached a timer driver. Its only effect was to **force every consumer of a *timed* toast to add an `embassy-time` dependency** just to express a timeout. Worse, `embassy_time::Duration` is tick-rate-dependent and only offers a *fallible* `TryFrom<core::time::Duration>`, so a caller holding a stdlib `Duration` couldn't pass it without an `unwrap`.

`embassy-time` remains an **internal** dependency (render-loop `Timer`/`with_timeout`, tick source) — it just leaves the public toast signature, so it no longer propagates to consumers.

## Notes

- No behavior change. The millisecond saturation cast is unchanged apart from `core::time::Duration::as_millis()` returning `u128` (cast updated accordingly).
- `0.3.1` was never published, so this is folded into a **`0.3.2`** release rather than a breaking bump.
- Originated from a downstream (oxiforge) code-review finding: generated toast helpers named `embassy_time::Duration` for what is conceptually "show this for N seconds".

## Verification

- `cargo check` clean, no warnings.
- Full integration suite: **514 passed / 0 failed**, including `auto_dismiss_after_duration` and sequential-playback toast tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)