### PR TITLE
feat: add post_toast_with for !Send toast views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3] — 2026-06-03
+
+### Added
+
+- **`navigator::post_toast_with`** — post a cross-task toast by handing the
+  render loop a `Send` *builder closure* instead of a `View` value. The view is
+  constructed render-side, so it need not be `Send` — which lets a toast store
+  its widget wrappers (the leak-free pattern, where `Drop` frees the style
+  `Rc`s) even though those wrappers are `!Send`. `post_toast` is now thin sugar
+  over it for trivial `Send` views. Unblocks posting real styled toasts from
+  background tasks and from `.on(event)` closures that cannot return a
+  `NavAction`.
+
 ## [0.3.2] — 2026-06-03
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "oxivgl"
 edition = "2024"
-version = "0.3.2"
+version = "0.3.3"
 license = "MIT OR Apache-2.0"
 description = "Safe no_std Rust bindings for LVGL — embedded GUI on ESP32 and host SDL2"
 repository = "https://github.com/emobotics-dev/oxivgl"

--- a/src/navigator.rs
+++ b/src/navigator.rs
@@ -777,10 +777,11 @@ impl Navigator {
     pub fn drain_toast_requests(&mut self) {
         while let Ok(req) = TOAST_CHANNEL.try_receive() {
             match req {
-                ToastRequest::Show(view, duration) => {
-                    // Box<dyn AnyView + Send> coerces to Box<dyn AnyView>
-                    // via unsizing — Send is dropped from the trait object.
-                    self.show_toast_boxed(view, duration);
+                ToastRequest::Show(make, duration) => {
+                    // Construct the view here, on the render task — so it need
+                    // not be `Send`. Only the builder closure crossed the
+                    // channel; `create()` then runs on the LVGL task as usual.
+                    self.show_toast_boxed(make(), duration);
                 }
                 ToastRequest::Dismiss => {
                     let _ = self.dismiss_toast();
@@ -820,10 +821,17 @@ fn activate_view_group(group: Option<crate::group::GroupRef>) {
 /// 4 outstanding requests tolerate brief contention without backpressure.
 const TOAST_QUEUE_CAPACITY: usize = 4;
 
-/// A request enqueued by [`post_toast`] / [`post_dismiss_toast`] and
-/// drained by [`Navigator::drain_toast_requests`].
+/// A boxed `Send` closure that constructs a toast view on the render task.
+///
+/// Only this closure crosses the [`TOAST_CHANNEL`]; the `View` it produces
+/// is built render-side, so the view itself need not be `Send` (widget
+/// wrappers hold raw `lv_obj_t` pointers and are `!Send`).
+type ToastBuilder = Box<dyn FnOnce() -> Box<dyn AnyView> + Send>;
+
+/// A request enqueued by [`post_toast`] / [`post_toast_with`] /
+/// [`post_dismiss_toast`] and drained by [`Navigator::drain_toast_requests`].
 enum ToastRequest {
-    Show(Box<dyn AnyView + Send>, Option<Duration>),
+    Show(ToastBuilder, Option<Duration>),
     Dismiss,
 }
 
@@ -832,27 +840,33 @@ enum ToastRequest {
 static TOAST_CHANNEL: Channel<CriticalSectionRawMutex, ToastRequest, TOAST_QUEUE_CAPACITY> =
     Channel::new();
 
-/// Queue a global passive toast from **any** async task — including
-/// background workers that hold no `Navigator` handle.
+/// Queue a global passive toast from **any** async task by handing the
+/// render loop a **builder closure** — including background workers that
+/// hold no `Navigator` handle.
 ///
-/// The request is processed on the next render-loop iteration
-/// (`run_app_nav` calls [`Navigator::drain_toast_requests`] every
-/// tick). It then flows through the same path as
+/// The closure is invoked on the next render-loop iteration (`run_app_nav`
+/// calls [`Navigator::drain_toast_requests`] every tick), which constructs
+/// the view and feeds it through the same path as
 /// [`Navigator::show_toast`], so all the passivity / persistence /
-/// auto-dismiss guarantees apply identically — the only difference is
-/// who initiated it.
+/// auto-dismiss guarantees apply identically — the only difference is who
+/// initiated it.
 ///
 /// Use this for **truly global status messages** (e.g. "No SD card",
 /// "BLE disconnected") raised before any particular view is on screen
 /// or from a task that has no reason to know about the active view.
 ///
-/// # `View: Send` constraint
+/// # Why a closure, not a `View`
 ///
-/// The view crosses a `Channel` boundary, so its concrete type must be
-/// `Send`. In practice toast views are simple config structs (text,
-/// color, icon source) — they don't store live `Obj` wrappers, which
-/// are `!Send`. Build the actual widgets inside `View::create` from
-/// `&Obj<'static>` parameters; do **not** keep them in struct fields.
+/// Only the closure crosses the `Channel`, so only `make` must be `Send` —
+/// and it genuinely is, since it captures just the toast's config
+/// (`String`, colors, icon source). The `View` it returns is built
+/// render-side, where `create()` already runs, so it **need not be
+/// `Send`**. This is what lets a toast store its widget wrappers (whose
+/// `Drop` frees the style `Rc`s, the leak-free pattern) even though those
+/// wrappers hold raw `lv_obj_t` pointers and are `!Send`.
+///
+/// For a toast whose view *is* `Send` (a trivial config struct that builds
+/// and forgets its widgets), [`post_toast`] is shorter sugar over this.
 ///
 /// # Backpressure
 ///
@@ -860,11 +874,27 @@ static TOAST_CHANNEL: Channel<CriticalSectionRawMutex, ToastRequest, TOAST_QUEUE
 /// If full, this call logs a warning and drops the request rather than
 /// blocking — toasts are notifications, not data; a dropped duplicate
 /// is preferable to async deadlock.
-pub fn post_toast<V: View + Send>(view: V, duration: Option<Duration>) {
-    let req = ToastRequest::Show(Box::new(view), duration);
+pub fn post_toast_with<V: View>(
+    make: impl FnOnce() -> V + Send + 'static,
+    duration: Option<Duration>,
+) {
+    let req = ToastRequest::Show(Box::new(move || Box::new(make()) as Box<dyn AnyView>), duration);
     if TOAST_CHANNEL.try_send(req).is_err() {
         warn!("post_toast: queue full ({}), request dropped", TOAST_QUEUE_CAPACITY);
     }
+}
+
+/// Queue a global passive toast from **any** async task by value.
+///
+/// Thin convenience over [`post_toast_with`] for toasts whose view is
+/// `Send` — i.e. a config struct that does not retain its widget wrappers.
+/// A view that *stores* its widgets (the leak-free pattern) is `!Send`;
+/// post it with [`post_toast_with`] instead, handing over a builder closure.
+///
+/// Same delivery, sequencing, and backpressure semantics as
+/// [`post_toast_with`].
+pub fn post_toast<V: View + Send>(view: V, duration: Option<Duration>) {
+    post_toast_with(move || view, duration);
 }
 
 /// Queue a request to dismiss the active toast from any async task.

--- a/tests/integration/navigator_toast.rs
+++ b/tests/integration/navigator_toast.rs
@@ -70,6 +70,24 @@ impl View for CountingToast {
     }
 }
 
+/// A toast view that *stores* its widget wrapper — the leak-free pattern,
+/// where the held `Label`'s `Drop` releases its styles on teardown. Holding
+/// an `Obj`-based wrapper (a raw `lv_obj_t` pointer) makes the view `!Send`,
+/// so it cannot be posted by value: only a builder closure can carry it to a
+/// background task. Used by `post_toast_with_shows_a_non_send_view`.
+#[derive(Default)]
+struct StoringToast {
+    label: Option<Label<'static>>,
+}
+impl View for StoringToast {
+    fn create(&mut self, container: &Obj<'static>) -> Result<(), WidgetError> {
+        let lbl = Label::new(container)?;
+        lbl.text("status");
+        self.label = Some(lbl);
+        Ok(())
+    }
+}
+
 /// A long duration that will not elapse during a test, so a timed toast
 /// stays put until it is explicitly dismissed.
 fn long() -> Option<Duration> {
@@ -277,6 +295,26 @@ fn post_toast_then_drain_shows_toast() {
 
     nav.drain_toast_requests();
     assert!(nav.has_toast(), "drain_toast_requests should pick up the queued show");
+    assert_eq!(sys_layer_child_count(), 1);
+
+    nav.dismiss_toast().expect("dismiss");
+}
+
+#[test]
+fn post_toast_with_shows_a_non_send_view() {
+    let mut nav = fresh_navigator();
+    assert!(!nav.has_toast());
+
+    // `StoringToast` retains a `Label<'static>` (raw pointer) and is `!Send`,
+    // so `post_toast` would reject it. A builder closure carries only its
+    // (Send) capture across the channel; the view is constructed render-side
+    // on drain. This test won't compile if the channel ever requires the
+    // view itself to be Send again.
+    oxivgl::navigator::post_toast_with(StoringToast::default, None);
+    assert!(!nav.has_toast(), "post must not bypass the drain step");
+
+    nav.drain_toast_requests();
+    assert!(nav.has_toast(), "drain should build the !Send view and show it");
     assert_eq!(sys_layer_child_count(), 1);
 
     nav.dismiss_toast().expect("dismiss");


### PR DESCRIPTION
## What

Add `navigator::post_toast_with` — post a cross-task toast by handing the render loop a `Send` **builder closure** instead of a `View` value:

```rust
pub fn post_toast_with<V: View>(
    make: impl FnOnce() -> V + Send + 'static,
    duration: Option<core::time::Duration>,
)
```

`post_toast<V: View + Send>` is now thin sugar over it.

## Why

`post_toast` sends the View **by value** across the toast channel, so `V: Send`. But the leak-free render pattern — store your widget wrappers so their `Drop` frees the style `Rc`s — makes any styled toast `!Send`, since widget wrappers hold raw `lv_obj_t` pointers. The repo's own `ToastView` proves it: it stores a `Label<'static>` and so **cannot be posted today**. `post_toast` could only accept trivial views that don't retain widgets — which either delete on `create` return or leak styles via `mem::forget`.

"Send the recipe, not the dish": only the closure crosses the channel, carrying just the toast's `Send` config (`String`, colors). The `!Send` View is constructed render-side where `create()` already runs, so it never crosses a thread boundary. No `unsafe` anywhere.

This also unblocks posting styled toasts from `.on(event)` closures, which can't return a `NavAction` and so must use the cross-task path.

## How

- `ToastRequest::Show` now carries a `ToastBuilder = Box<dyn FnOnce() -> Box<dyn AnyView> + Send>`; `drain_toast_requests` invokes it render-side, then feeds the result through the unchanged `show_toast_boxed`/sequencing path.
- `post_toast` re-expressed as `post_toast_with(move || view, duration)` — one internal code path, convenience preserved for `Send` unit-struct toasts.

## Verification

- `cargo check` clean, zero `unsafe`, no new deps.
- Integration suite **515 passed / 0 failed**, including a new `post_toast_with_shows_a_non_send_view` test backed by a `StoringToast` fixture that retains a `Label<'static>` (the `!Send`, leak-free pattern). It's a compile-time regression guard — the test won't build if the channel ever requires the view itself to be `Send` again.

Follows #98 (which moved the toast timeout to `core::time::Duration`, used in this signature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)