### PR TITLE
feat: resource diagnostics + memory tuning guidance

### DIFF
--- a/docs/cr-navigator-modal-background-tree-residency.md
+++ b/docs/cr-navigator-modal-background-tree-residency.md
@@ -1,0 +1,85 @@
+# CR: navigator modal keeps the full background view tree resident (peak-heap OOM)
+
+> **Status:** open — fix intended in **oxivgl navigator** (`src/navigator.rs`).
+> **Severity:** high — peak-heap OOM when a modal opens over a heap-heavy view on
+> a memory-constrained target (ESP32-S3, ~16 KB free LVGL heap shared with the BLE
+> blob). Half-builds the modal, leaves a near-opaque scrim, never recovers →
+> **solid black display**.
+> **Origin:** alternator-regulator OSD target-factor modal; cores3 (ESP32-S3)
+> cold-boot black screen, 2026-06-10. Three-way heap audit + HIL evidence below.
+
+## Symptom
+
+Opening `NavAction::Modal` over an active full-screen view OOMs on cores3: during
+the modal's `create()`, an `lv_malloc` returns NULL → `LV_ASSERT_MALLOC` →
+`LV_ASSERT_HANDLER` (the app panics loudly). The modal tree is half-built, the
+backdrop's near-opaque scrim covers the screen, and the modal never dismisses →
+**solid black, no recovery**. fire27 (more free heap, less BLE pressure) survives
+the same modal.
+
+## Root cause — background tree + modal tree fully resident simultaneously
+
+`modal()` / `modal_boxed` (`navigator.rs:363-438`) builds the backdrop + the
+modal's widget tree on `lv_layer_top()` **while the background view's entire
+widget tree stays alive** — by design ("modals overlay, full-screen views
+replace", `spec-navigation.md` §2.4). Peak resident heap therefore equals:
+
+```
+background-view tree  +  backdrop  +  modal tree  +  their style/draw allocs   (all at once)
+```
+
+### Measured (audit of generated views + fire27 `:free` / heap reports)
+
+- Per-object cost ≈ 120–200 B (`lv_obj_t` + `spec_attr` + `styles[]`) + ~16 B per
+  `add_style` slot. (`lv_obj.c:419`, `lv_obj_style.c:136/765`.)
+- cores3 steady-state heap (BLE blob + GlanceView) = **41 KB used / 57 KB → ~16 KB free**.
+- OSD modal ≈ 11 objects + ~10 inline styles ≈ 2–3 KB resident, **plus** a transient
+  ~2 KB card-shadow spike at create.
+- Over **GlanceView** (~22 widgets + 12 styles ≈ 4–6 KB) the margin is already thin.
+  Over **MeterView** (67 widgets + 43 styles ≈ 12–16 KB resident) the background
+  tree alone nearly exhausts the 16 KB *before the modal allocates anything* →
+  guaranteed OOM.
+- fire27 (57 KB heap, lighter BLE): heap peaks **33 KB / 57 KB** → survives.
+
+The retained background tree is **invisible anyway**: the OSD scrim is
+`bg_opa ≈ 150` (near-opaque black), so almost nothing of the background composites
+through.
+
+## Proposed fix
+
+On modal open, tear down the background screen's **widgets** (not its `View`
+struct) and rebuild them on dismiss — the same widget teardown/rebuild that
+`push`/`pop` already use (`lv_obj_clean`, `navigator.rs`). The evolved `View`
+trait already supports this: `will_hide()` → `lv_obj_clean` → (on dismiss)
+`create()` → `did_show()`. Reclaims the full background-tree heap (~4–16 KB) for
+the modal's lifetime.
+
+| Option | Heap reclaimed | Trade-off |
+|---|---|---|
+| **A. Free background widgets on open, rebuild on dismiss** (recommended) | full background tree (~4–16 KB) | one rebuild (~ms) on dismiss; the background can't composite *live* under the modal — fine, the scrim is near-opaque |
+| B. Hide background tree (`HIDDEN` flag) | **0 KB** (objects stay allocated) | only saves render cost, **does not fix the OOM** — reject |
+| C. Render the modal as a full-screen `Replace`/`push` | full background tree | loses the dim-live-screen *semantics*; visually equivalent here (scrim hides the background) |
+
+Recommend **A**. An optional `modal_preserving_background()` variant could keep
+today's behavior for heap-rich targets or genuinely translucent overlays, with
+A as the default.
+
+## Non-fixes — ruled out by the audit (do not chase)
+
+- **Semi-transparent scrim does NOT allocate a full-screen transparency layer
+  buffer.** `bg_opa < 255` is a per-pixel blend, not a layer; `calculate_layer_type`
+  (`lv_obj_style.c:1087-1097`) triggers a layer only on `opa_layered` / transform /
+  `bitmap_mask` / non-normal `blend_mode` — none used by the OSD. **0 KB to save.**
+- **Draw buffers are correctly in `.bss`** (`LVGL_BUFS`, `ui/mod.rs`), not heap.
+- **No global LVGL heap pool** (`LV_USE_STDLIB_MALLOC = CLIB`); style/image/object
+  caches already at 0 in `lv_conf.h`.
+- **Shadows are transient** (alloc+free within the draw call) — but the ~2 KB
+  card-shadow spike *coincides with the create-time OOM instant*; cheap app-side
+  mitigation is to lower `shadow_width`.
+
+## HIL evidence
+
+fire27 (1 Mbaud UART, `reset_reason = ChipPowerOn`): clean boot, heap peaks
+33 KB/57 KB, OSD opens + dismisses. cores3 (CDC): firmware stays alive (60 s heap
+reports) at 41 KB/57 KB used while the display is solid black — i.e. the modal
+OOM'd at create and left a broken overlay, not a crash-loop.

--- a/docs/memory-tuning.md
+++ b/docs/memory-tuning.md
@@ -1,0 +1,121 @@
+# Memory tuning for widget-heavy UIs
+
+Practical guidance for keeping heap and stack in budget on memory-constrained
+targets (ESP32 family). Grounded in measurement — every claim here is backed by
+the [`diag`](../src/diag.rs) tooling or a cited audit, not intuition.
+
+> **Scope.** This is general guidance for the library and its users. For the
+> specific peak-heap OOM when a modal opens over a heavy view, see
+> [`cr-navigator-modal-background-tree-residency.md`](cr-navigator-modal-background-tree-residency.md).
+
+## 1. Measure first
+
+Use [`oxivgl::diag`](../src/diag.rs). The portable, deterministic signal is the
+**widget census** — a count of real `lv_obj` instances and nesting depth. Every
+object-reduction technique moves it directly, and it works the same on host and
+target.
+
+```rust
+use oxivgl::diag::{census, Budget, assert_budget};
+
+// After a view's create():
+let c = census(&screen);          // e.g. "61 objects, depth 2, ~9760 B est"
+log::info!("{c}");
+
+// Fail loudly in debug if a view outgrows its envelope (no-op in release):
+assert_budget(&screen, &Budget { max_objects: 80, max_depth: 6 });
+```
+
+For *live* heap/stack on target, implement [`ResourceProbe`](../src/diag.rs):
+`free_heap_bytes` from `esp_alloc` stats, `stack_high_water_bytes` from the
+FreeRTOS task high-water mark. There is no portable default — off-target these
+are meaningless, so [`NullProbe`] returns `None`.
+
+### Why not `lv_mem_monitor`?
+
+These bindings ship `LV_USE_STDLIB_MALLOC = LV_STDLIB_CLIB`, so LVGL has no
+internal pool to introspect — it calls libc `malloc` directly and
+`lv_mem_monitor` reports nothing useful. The figure that matters on target is
+the **system** heap (esp-hal), exposed via a `ResourceProbe`. For the same
+reason, a Rust `#[global_allocator]` counter (as in `tests/leak_check.rs`) sees
+only Rust-side bytes, **not** LVGL C-side object allocations.
+
+## 2. What is already lean — don't chase these
+
+Measured, so nobody re-spends effort here:
+
+- **Wrapper struct size** (`tests/integration/diag.rs::wrapper_struct_sizes`):
+  `Obj`/`Label`/`Button` = 40 B, `Bar`/`Arc` = 48 B. An `Obj` is a raw handle
+  (8 B) + an **empty, unallocated** `RefCell<Vec<Style>>` (32 B, struct size
+  only) + a ZST. This is inline storage (lives in the view), not per-widget
+  heap.
+- **No per-widget heap** until `add_style` is called — `Vec::new()` does not
+  allocate. A "lazy `_styles`" rewrite saves nothing: an empty `Vec` already
+  costs no heap, and `Option<Vec<_>>` is the same size as `Vec<_>`.
+- **Event handlers are zero-allocation** — `Obj::on` stores a bare `fn` pointer
+  in LVGL user-data; the `View` trampoline stores a raw `*mut V`. No boxed
+  closures, no `Rc`, no per-handler heap.
+
+## 3. Levers that pay off without costing per-frame compute
+
+Ordered by leverage. All of these reduce memory while leaving (or improving)
+runtime compute. Techniques that trade compute for memory — e.g. painting
+decorations in a draw callback instead of instantiating child objects — are
+**deliberately excluded**: paying per-frame CPU for a few kB is the wrong trade
+on these targets.
+
+1. **Free off-screen widget trees.** A view/page/tab that isn't visible should
+   not keep its widget tree resident. The `View` lifecycle already supports it:
+   `will_hide()` → `lv_obj_clean` → (on return) `create()` → `did_show()` — the
+   same teardown `push`/`pop` use. Cost is one rebuild on navigation
+   (occasional, not per-frame). This is the single largest reclaimable chunk on
+   a multi-screen UI.
+
+2. **Share styles; avoid inline setters at scale.** A shared `static`/`Rc`
+   `Style` applied with `add_style` to many widgets amortizes to one descriptor;
+   per-widget inline `style_*(…)` setters write a local style entry per property
+   group per object. Sharing reduces both heap and style-refresh compute.
+
+3. **Flatten the tree.** Layout, style refresh, and draw all recurse over
+   depth — deep nesting costs heap *per container* and stack *per level*. A
+   shallow, wide tree wins on both. Nesting depth is exactly what `census`
+   reports as `max_depth`.
+
+4. **Keep objects at base size.** `lv_obj` only allocates its larger `spec_attr`
+   block when an object gains events, groups, or certain flags. Don't attach
+   event trampolines or add to groups indiscriminately — purely decorative
+   objects then stay at base size.
+
+5. **Tame draw-time spikes.** Several effects allocate a full-region scratch
+   buffer *at draw time* — the transient peak that actually trips an OOM:
+   - **Shadows**: buffer ∝ object area × `shadow_width`. Lower it, or
+     precompose the card as one image.
+   - **`opa_layered`, transforms, `clip_corner` (radius + overflow-hidden),
+     bitmap masks, non-normal blend modes** each force a full layer buffer.
+     Avoid them on large areas. (A plain `bg_opa < 255` does *not* — it is a
+     per-pixel blend, not a layer.)
+   - **Dithered / multi-stop gradients** allocate; a 2-stop undithered gradient
+     does not.
+
+6. **Compile out what you don't use** (`lv_conf.h`, app-owned). Disable unused
+   widgets (smaller `.text`, fewer registrations). In production builds, turn
+   **off** the dev-only `LV_USE_PERF_MONITOR` / `LV_USE_SYSMON` (each adds a
+   persistent overlay object *and* per-frame work) and lower `LV_LOG_LEVEL` /
+   the `LV_LOG_TRACE_*` flags (log strings cost flash, emission costs cycles).
+
+## 4. Stack
+
+- **Right-size the LVGL task stack against the deepest path** (deepest nesting +
+  the heaviest custom-draw callback + flush), then measure the high-water mark
+  rather than guessing — over-provisioning steals RAM the heap could use.
+- **No large buffers on the LVGL task stack.** Format into a bounded
+  `heapless::String` or static scratch, not a big stack array in
+  `create()`/`update()`.
+- **Shallower trees** (lever 3) also cap layout/draw recursion depth.
+
+## 5. Standing instrument
+
+Wire `census` (and a `ResourceProbe` on target) into your existing heap reports,
+and put a per-view `assert_budget` right after each `create()`. A view that
+regresses past its envelope then fails in CI/HIL instead of OOMing a device in
+the field.

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Resource diagnostics for widget-heavy UIs.
+//!
+//! Two complementary signals:
+//!
+//! 1. [`census`](crate::diag::census) walks a widget subtree and counts objects and nesting depth.
+//!    This is the portable, deterministic metric — it counts real `lv_obj`
+//!    instances regardless of how the C heap is configured, and every
+//!    object-reduction technique (virtualised lists, drawing instead of
+//!    instantiating, freeing off-screen trees) moves it directly.
+//!
+//! 2. [`ResourceProbe`](crate::diag::ResourceProbe) is a pluggable hook for *live* heap and task-stack
+//!    figures. There is no portable way to read these — on host they are not
+//!    meaningful, and on ESP32 the heap and task stacks are owned by the
+//!    application (esp-hal / FreeRTOS), not the library. Apps supply an impl;
+//!    the default [`NullProbe`](crate::diag::NullProbe) reports nothing.
+//!
+//! ## Why not `lv_mem_monitor`?
+//!
+//! With `LV_USE_STDLIB_MALLOC = LV_STDLIB_CLIB` (the configuration these
+//! bindings ship with), LVGL has no internal pool to introspect — it delegates
+//! straight to libc `malloc`, so `lv_mem_monitor` reports nothing useful. The
+//! figure that actually matters on target is the *system* heap (esp-hal), which
+//! a [`ResourceProbe`](crate::diag::ResourceProbe) exposes.
+
+use crate::widgets::Obj;
+
+/// Estimated bytes per `lv_obj`, measured on ESP32-S3 (`lv_obj_t` + `spec_attr`
+/// + a small `styles[]`). The audit in
+/// `docs/cr-navigator-modal-background-tree-residency.md` puts this at
+/// ~120–200 B; we use the midpoint for estimates.
+pub const BYTES_PER_OBJECT_EST: u32 = 160;
+
+/// A census of a widget subtree: how many objects it holds and how deep it
+/// nests. Both numbers drive heap *and* stack cost — object count dominates
+/// heap, nesting depth bounds the recursion depth of layout, style refresh and
+/// draw (and therefore the LVGL task's stack high-water mark).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Census {
+    /// Total objects in the subtree, including the root.
+    pub objects: u32,
+    /// Deepest nesting below the root (the root itself is depth 0).
+    pub max_depth: u16,
+}
+
+impl Census {
+    /// Estimated heap footprint in bytes (`objects` × [`BYTES_PER_OBJECT_EST`]).
+    ///
+    /// A portable estimate, **not** a live reading — styles, draw buffers and
+    /// per-object variation are not captured. For the real figure on target,
+    /// read a [`ResourceProbe`]. Saturates rather than overflowing.
+    pub const fn estimated_heap_bytes(&self) -> u32 {
+        self.objects.saturating_mul(BYTES_PER_OBJECT_EST)
+    }
+
+    /// Returns `true` if this census exceeds either ceiling of a [`Budget`].
+    pub const fn exceeds(&self, budget: &Budget) -> bool {
+        self.objects > budget.max_objects || self.max_depth > budget.max_depth
+    }
+}
+
+impl core::fmt::Display for Census {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "{} objects, depth {}, ~{} B est",
+            self.objects,
+            self.max_depth,
+            self.estimated_heap_bytes()
+        )
+    }
+}
+
+/// A per-view resource ceiling. Pair with [`Census::exceeds`] (or
+/// [`assert_budget`]) to fail loudly in debug builds when a view's widget tree
+/// grows past its envelope, instead of silently OOMing a memory-constrained
+/// target at runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Budget {
+    /// Maximum allowed object count for the subtree.
+    pub max_objects: u32,
+    /// Maximum allowed nesting depth.
+    pub max_depth: u16,
+}
+
+impl Budget {
+    /// A budget with the given object ceiling and an unbounded depth.
+    pub const fn objects(max_objects: u32) -> Self {
+        Self { max_objects, max_depth: u16::MAX }
+    }
+}
+
+/// Walk `root` and all descendants, returning the subtree [`Census`].
+///
+/// `root` is typically a screen (`lv_screen_active`) or a container. The walk
+/// recurses to `max_depth`; widget trees are normally wide rather than deep, so
+/// this stays shallow — see the "flatten the tree" guidance.
+pub fn census(root: &Obj) -> Census {
+    let mut c = Census::default();
+    walk(root, 0, &mut c);
+    c
+}
+
+fn walk(obj: &Obj, depth: u16, c: &mut Census) {
+    c.objects += 1;
+    if depth > c.max_depth {
+        c.max_depth = depth;
+    }
+    let n = obj.get_child_count();
+    for i in 0..n as i32 {
+        if let Some(child) = obj.get_child(i) {
+            walk(&child, depth + 1, c);
+        }
+    }
+}
+
+/// In a debug build, panic if `root`'s census exceeds `budget`; no-op in
+/// release. Use as a guard right after a view's `create()` so a regression in
+/// widget count fails CI/HIL rather than a customer's device.
+#[track_caller]
+pub fn assert_budget(root: &Obj, budget: &Budget) {
+    debug_assert!(
+        !census(root).exceeds(budget),
+        "widget census {} exceeds budget (max {} objects, depth {})",
+        census(root),
+        budget.max_objects,
+        budget.max_depth,
+    );
+}
+
+/// A pluggable source of live heap and task-stack figures.
+///
+/// All methods default to `None` ("unknown"); implement only what a platform
+/// can answer. On ESP32 an app typically backs `free_heap_bytes` with
+/// `esp_alloc` heap stats and `stack_high_water_bytes` with the FreeRTOS task
+/// high-water mark.
+pub trait ResourceProbe {
+    /// Free system-heap bytes right now, if known.
+    fn free_heap_bytes(&self) -> Option<usize> {
+        None
+    }
+
+    /// Largest contiguous free heap block, if known — a fragmentation
+    /// indicator (a low value with high total free means a fragmented heap).
+    fn largest_free_block(&self) -> Option<usize> {
+        None
+    }
+
+    /// Minimum free stack ever observed for the current task (its high-water
+    /// mark), in bytes, if known.
+    fn stack_high_water_bytes(&self) -> Option<usize> {
+        None
+    }
+}
+
+/// A [`ResourceProbe`] that knows nothing — the host default. Live heap and
+/// stack are not meaningful off-target, so every method returns `None`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NullProbe;
+
+impl ResourceProbe for NullProbe {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,8 @@ pub mod translation;
 pub mod group;
 /// Grid navigation (`LV_USE_GRIDNAV`) — keyboard-driven focus inside containers.
 pub mod gridnav;
+/// Resource diagnostics: widget-tree census, per-view budgets, heap/stack probe.
+pub mod diag;
 
 /// Declare an LVGL image asset compiled by `oxivgl-build`.
 ///

--- a/tests/integration/diag.rs
+++ b/tests/integration/diag.rs
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Resource-diagnostics tests: widget census, budgets, and a baseline record
+//! for a representative widget-heavy tree.
+
+use crate::common::{fresh_screen, pump};
+
+use oxivgl::diag::{assert_budget, census, Budget, Census, BYTES_PER_OBJECT_EST};
+use oxivgl::widgets::{Label, Obj};
+
+/// Build a `rows`-wide, two-deep tree (each row is an `Obj` holding one
+/// `Label`) under a fresh container. Returns the container plus the retained
+/// owned widgets — they must be kept alive or `Drop` deletes the tree.
+fn build_tree(rows: usize) -> (Obj<'static>, Vec<Obj<'static>>, Vec<Label<'static>>) {
+    let screen = fresh_screen();
+    let container = Obj::new(&screen).unwrap();
+    let mut row_objs = Vec::with_capacity(rows);
+    let mut labels = Vec::with_capacity(rows);
+    for _ in 0..rows {
+        let row = Obj::new(&container).unwrap();
+        let label = Label::new(&row).unwrap();
+        row_objs.push(row);
+        labels.push(label);
+    }
+    pump();
+    (container, row_objs, labels)
+}
+
+#[test]
+fn census_counts_objects_and_depth() {
+    let (container, _rows, _labels) = build_tree(30);
+    let c = census(&container);
+    // container + 30 rows + 30 labels.
+    assert_eq!(c.objects, 61, "expected 1 container + 30 rows + 30 labels");
+    // container(0) → row(1) → label(2).
+    assert_eq!(c.max_depth, 2);
+}
+
+#[test]
+fn census_empty_subtree_is_one_object() {
+    let screen = fresh_screen();
+    let leaf = Obj::new(&screen).unwrap();
+    let c = census(&leaf);
+    assert_eq!(c, Census { objects: 1, max_depth: 0 });
+}
+
+#[test]
+fn estimated_heap_bytes_uses_coefficient() {
+    let (container, _rows, _labels) = build_tree(10);
+    let c = census(&container);
+    assert_eq!(c.objects, 21);
+    assert_eq!(c.estimated_heap_bytes(), 21 * BYTES_PER_OBJECT_EST);
+}
+
+#[test]
+fn budget_detects_overflow() {
+    let (container, _rows, _labels) = build_tree(30);
+    let c = census(&container);
+    assert!(c.exceeds(&Budget::objects(50)), "61 > 50");
+    assert!(!c.exceeds(&Budget::objects(100)), "61 < 100");
+    assert!(c.exceeds(&Budget { max_objects: 1000, max_depth: 1 }), "depth 2 > 1");
+}
+
+#[test]
+fn assert_budget_passes_within_envelope() {
+    let (container, _rows, _labels) = build_tree(5);
+    // 11 objects, depth 2 — comfortably inside.
+    assert_budget(&container, &Budget { max_objects: 50, max_depth: 4 });
+}
+
+/// Reports the Rust-side struct size of each widget wrapper, and proves that a
+/// freshly-created widget that never calls `add_style` performs ZERO Rust-side
+/// heap allocation (the `_styles` `Vec` is empty and unallocated). Run with
+/// `--nocapture` to see the sizes.
+#[test]
+fn wrapper_struct_sizes_and_zero_heap() {
+    use core::mem::size_of;
+    use oxivgl::widgets::{Arc, Bar, Button, Label, Scale};
+    println!(
+        "wrapper size_of (bytes): Obj={} Label={} Button={} Bar={} Arc={} Scale={}",
+        size_of::<Obj>(),
+        size_of::<Label>(),
+        size_of::<Button>(),
+        size_of::<Bar>(),
+        size_of::<Arc>(),
+        size_of::<Scale>(),
+    );
+    // The base wrappers are a raw handle + an (empty, unallocated) style Vec +
+    // a ZST PhantomData — no per-widget heap until a style is retained.
+    assert!(size_of::<Label>() == size_of::<Obj>(), "Label adds no fields");
+    assert!(size_of::<Button>() == size_of::<Obj>(), "Button adds no fields");
+}
+
+/// Records the census of a representative widget-heavy tree. Run with
+/// `--nocapture` to print the baseline; the assertions pin it so a regression
+/// (a refactor that inflates object count) fails here.
+#[test]
+fn baseline_widget_heavy_tree() {
+    let (container, _rows, _labels) = build_tree(30);
+    let c = census(&container);
+    println!(
+        "BASELINE widget-heavy tree: {c}  (coefficient {BYTES_PER_OBJECT_EST} B/object)"
+    );
+    assert_eq!(c.objects, 61);
+    assert_eq!(c.max_depth, 2);
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -8,6 +8,7 @@
 mod common;
 
 mod anim;
+mod diag;
 mod draw;
 mod event;
 mod group;


### PR DESCRIPTION
## Summary

General memory-optimization groundwork for widget-heavy UIs, **measurement first**. Adds `oxivgl::diag` plus a tuning guide grounded in measured findings.

### `oxivgl::diag` (src/diag.rs)
- **`census(&Obj) -> Census`** — walks a subtree, counts real `lv_obj` instances + nesting depth, with an `estimated_heap_bytes()` coefficient. The portable, allocator-agnostic signal: it counts objects regardless of how the C heap is configured, identical on host and target. Every object-reduction technique moves it directly.
- **`Budget` / `assert_budget`** — per-view ceilings; debug-panics when a view outgrows its envelope (no-op in release), so regressions fail in CI/HIL instead of OOMing a device.
- **`ResourceProbe`** — pluggable live heap/stack source for target (esp-hal free heap, FreeRTOS stack high-water). Host default `NullProbe` returns `None`.
- **Deliberately not `lv_mem_monitor`**: under `LV_STDLIB_CLIB` LVGL delegates to libc malloc and has no pool to introspect; the real figure on target is the system heap behind a `ResourceProbe`.

### docs/memory-tuning.md
Captures the **measured** findings so they aren't re-litigated:
- Wrappers are already lean — `Obj`/`Label`/`Button` = 40 B, **no per-widget heap** until `add_style` (empty `Vec` doesn't allocate); event handlers/View trampolines are zero-allocation. The often-suggested "lazy `_styles`" rewrite is a proven non-win.
- The compute-safe levers, ranked (free off-screen trees, share styles, flatten the tree, keep objects at base size, tame draw-time spikes, compile out unused widgets). Compute-for-memory trades (e.g. draw-instead-of-instantiate) are explicitly excluded.

Also commits `docs/cr-navigator-modal-background-tree-residency.md` (the navigator modal CR that motivated this), preserving it under version control.

## Test plan
- 526 integration tests pass, incl. new `diag::*`: census count/depth on a known 61-object tree, empty-subtree, heap estimate, budget overflow, `assert_budget`, wrapper struct sizes, and a recorded baseline (`61 objects, depth 2, ~9760 B est`).
- Unit + doc tests pass; `missing-docs` clean for the new module.
- Host-only; no target/HIL exercised. The esp-hal `ResourceProbe` impl is documented but app-supplied and not verified on hardware here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)