### PR TITLE
Release v0.4.0: deprecate inline style setters + migrate examples to shared styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ docs/plans/
 oxivgl-sys/target/
 .devcontainer/.clco-built
 .cargo/credentials.toml
+
+# Scratch / run output (clco)
+work/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] — 2026-06-10
+
+### Added
+
+- **Resource diagnostics (`diag` module).** `census()` walks a widget subtree
+  and reports object count + nesting depth (with an estimated-heap-bytes
+  coefficient); `Budget` / `assert_budget` enforce per-view ceilings;
+  `ResourceProbe` (host default `NullProbe`) is a pluggable hook for live
+  on-target heap/stack figures. See `docs/memory-tuning.md`.
+- **`Style::new(|s| …)`** — one-call shared-style constructor collapsing
+  `StyleBuilder::new()` + setters + `.build()`. `add_style` `Rc`-retains the
+  style, so a built `Style` may be applied across many widgets and the handle
+  dropped (build-and-forget).
+- **`StyleBuilder` parity methods**, so every shareable style property has a
+  shared-style path: `pad_hor`, `pad_bottom`, `pad_column`, `pad_row`, `size`,
+  `clip_corner`, `text_align`, `base_dir`, `radial_offset`, `line_opa`,
+  `arc_rounded`, `blur_radius`, `blur_backdrop`, `radius_circle`, and the
+  `bg_image_recolor` / `bg_image_recolor_hex` / `bg_image_recolor_opa` family.
+- **Background-image wrappers on `Obj`**: `style_bg_image_src` (image
+  descriptor), `style_bg_image_recolor[_hex]`, `style_bg_image_recolor_opa`.
+- **Guide** `docs/memory-tuning.md` — measuring and reducing heap/stack on
+  widget-heavy UIs.
+- **Examples** `shared_styles1` (a style guide built from shared styles) and
+  `widget_bar8` (recolored background image).
+
+### Deprecated
+
+- **49 inline `style_*` setters on `Obj`.** Each inline setter allocates a
+  per-object local style; build a shared `Style` (`Style::new`) and apply it
+  with `add_style` to amortize to one property buffer at scale — a heap *and*
+  style-refresh-compute win wherever a treatment repeats. Transforms and
+  image-content setters are intentionally not deprecated (per-instance /
+  dynamic). See `docs/memory-tuning.md`.
+
+### Changed
+
+- All bundled examples migrated off inline setters to shared `Style` +
+  `add_style` (verified pixel-identical via before/after screenshots).
+
 ## [0.3.4] — 2026-06-04
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "oxivgl"
 edition = "2024"
-version = "0.3.4"
+version = "0.4.0"
 license = "MIT OR Apache-2.0"
 description = "Safe no_std Rust bindings for LVGL — embedded GUI on ESP32 and host SDL2"
 repository = "https://github.com/emobotics-dev/oxivgl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ exclude = [
     "examples/doc/screenshots/",
     "examples/common/",
     "run_*.sh",
+    "RELEASE_NOTES_*.md",
 ]
 
 [package.metadata.docs.rs]

--- a/RELEASE_NOTES_v0.4.0.md
+++ b/RELEASE_NOTES_v0.4.0.md
@@ -1,0 +1,93 @@
+# oxivgl v0.4.0
+
+This release moves oxivgl toward a **shared-style** model for memory-efficient
+UIs, adds a **resource-diagnostics** toolkit for widget-heavy screens, and
+rounds out the styling and background-image APIs. It bundles all work since
+0.3.4.
+
+## Highlights
+
+### 🎨 Shared styles are the recommended path — inline setters deprecated
+
+Per-object inline `style_*` setters each allocate a **per-object local style**
+(a `styles[]` entry *plus* its own property buffer). A shared `Style` amortizes
+to **one** buffer for every widget that uses it — a heap *and* style-refresh
+compute win wherever a treatment repeats.
+
+- New **`Style::new(|s| …)`** — a one-call constructor (no separate `.build()`).
+- `add_style` `Rc`-retains the style, so you can **build once, apply to many
+  widgets, and drop your handle** ("build-and-forget").
+- **49 inline `style_*` setters are now `#[deprecated]`.** Migrate them to
+  shared styles. Transforms and image-content setters are intentionally *not*
+  deprecated (they're per-instance / dynamic).
+
+```rust
+// before — a per-object local style on each widget
+label.bg_color(0x222244).bg_opa(255).radius(8);
+
+// after — build once, share across widgets
+let card = Style::new(|s| { s.bg_color_hex(0x222244).bg_opa(255).radius(8); });
+label.add_style(&card, Selector::DEFAULT);
+```
+
+See **[docs/memory-tuning.md](https://github.com/emobotics-dev/oxivgl/blob/v0.4.0/docs/memory-tuning.md)**
+for the rationale and a measurement guide. All bundled examples have been
+migrated (verified pixel-identical via before/after screenshots).
+
+### 📊 Resource diagnostics (`diag` module)
+
+Measure what widget-heavy UIs actually cost:
+
+- **`census(&obj)`** — object count + nesting depth for a subtree, with an
+  estimated-heap-bytes coefficient.
+- **`Budget` / `assert_budget`** — per-view ceilings that fail loudly in debug
+  builds (no-op in release), so a regression trips CI/HIL instead of a device.
+- **`ResourceProbe`** — a pluggable hook for live on-target heap/stack figures
+  (host default `NullProbe`). `lv_mem_monitor` is intentionally avoided under
+  `LV_STDLIB_CLIB`; the meaningful figure is the system (esp-hal) heap.
+
+### 🧱 Fuller styling + background-image API
+
+- New `StyleBuilder` methods for full parity with the inline setters:
+  `pad_hor`, `pad_bottom`, `pad_column`, `pad_row`, `size`, `clip_corner`,
+  `text_align`, `base_dir`, `radial_offset`, `line_opa`, `arc_rounded`,
+  `blur_radius`, `blur_backdrop`, `radius_circle`.
+- Background-image recolor wrappers on both `Obj` and `StyleBuilder`
+  (`style_bg_image_src`, `bg_image_recolor[_hex]`, `bg_image_recolor_opa`).
+
+## ⚠️ Upgrading
+
+Nothing is removed and nothing breaks at runtime — the deprecations are
+**compile-time warnings only**. This is a **minor** bump, so `oxivgl = "0.3"`
+users must move to `"0.4"` to receive it (and to see the deprecation warnings).
+Migrate inline styling to shared `Style` + `add_style` at your own pace; for
+genuinely *dynamic* per-frame styling (animated opacity, live recolor), keep the
+inline setter under a localized `#[allow(deprecated)]`.
+
+## Full changes
+
+### Added
+
+- `diag` module: `census()`, `Census`, `Budget` / `assert_budget`,
+  `ResourceProbe` / `NullProbe`.
+- `Style::new(|s| …)` shared-style constructor.
+- `StyleBuilder` parity methods (see Highlights) and the `bg_image_recolor`
+  family on `Style`.
+- Background-image wrappers on `Obj`: `style_bg_image_src`,
+  `style_bg_image_recolor[_hex]`, `style_bg_image_recolor_opa`.
+- `docs/memory-tuning.md` — measuring and reducing heap/stack on widget-heavy
+  UIs.
+- Examples `shared_styles1` (a style guide built from shared styles) and
+  `widget_bar8` (recolored background image).
+
+### Deprecated
+
+- 49 inline `style_*` setters on `Obj` — build a shared `Style` (`Style::new`)
+  and apply with `add_style`.
+
+### Changed
+
+- All bundled examples migrated off inline setters to shared `Style` +
+  `add_style`.
+
+**Full diff:** https://github.com/emobotics-dev/oxivgl/compare/v0.3.4...v0.4.0

--- a/examples/anim2.rs
+++ b/examples/anim2.rs
@@ -8,7 +8,7 @@
 
 use oxivgl::{
     anim::{anim_path_ease_in_out, anim_set_size, anim_set_x, Anim, ANIM_REPEAT_INFINITE},
-    style::{palette_main, Palette, Selector},
+    style::{palette_main, Palette, Selector, Style},
     view::{NavAction, View},
     widgets::{Align, Obj, WidgetError, RADIUS_MAX},
 };
@@ -23,8 +23,10 @@ impl View for Anim2 {
 
         let obj = Obj::new(container)?;
         obj.remove_scrollable();
-        obj.style_bg_color(palette_main(Palette::Red), Selector::DEFAULT);
-        obj.radius(RADIUS_MAX, Selector::DEFAULT);
+        let obj_style = Style::new(|s| {
+            s.bg_color(palette_main(Palette::Red)).radius(RADIUS_MAX as i16);
+        });
+        obj.add_style(&obj_style, Selector::DEFAULT);
         obj.align(Align::LeftMid, 10, 0);
 
         let mut a = Anim::new();

--- a/examples/anim3.rs
+++ b/examples/anim3.rs
@@ -18,7 +18,7 @@ use oxivgl::{
     event::Event,
     layout::{GridAlign, GridCell, GRID_TEMPLATE_LAST, grid_fr},
     math::bezier3,
-    style::{Palette, Selector, palette_main},
+    style::{Palette, Selector, Style, palette_main},
     view::{NavAction, View},
     widgets::{Button, Chart, ChartAxis, ChartSeries, ChartType, Label, Obj, Part,
         Slider, WidgetError,
@@ -66,9 +66,10 @@ impl View for Anim3 {
     fn create(&mut self, container: &Obj<'static>) -> Result<(), WidgetError> {
 
         let cont = Obj::new(container)?;
-        cont.pad(2);
-        cont.style_pad_column(10, Selector::DEFAULT);
-        cont.style_pad_row(10, Selector::DEFAULT);
+        let cont_style = Style::new(|s| {
+            s.pad_all(2).pad_column(10).pad_row(10);
+        });
+        cont.add_style(&cont_style, Selector::DEFAULT);
         cont.set_grid_dsc_array(&COL_DSC, &ROW_DSC);
         cont.size(320, 240).center();
         cont.remove_scrollable();
@@ -78,12 +79,19 @@ impl View for Anim3 {
         let anim_obj = Obj::new(&cont)?;
         anim_obj.size(30, 30);
         anim_obj.remove_scrollable();
-        anim_obj.style_bg_color(palette_main(Palette::Red), Selector::DEFAULT);
-        anim_obj.bg_opa(255);
+        let anim_obj_style = Style::new(|s| {
+            s.bg_color(palette_main(Palette::Red)).bg_opa(255);
+        });
+        anim_obj.add_style(&anim_obj_style, Selector::DEFAULT);
         anim_obj.set_grid_cell(
             GridCell::new(GridAlign::Start, 0, 1),
             GridCell::new(GridAlign::Start, 0, 1),
         );
+
+        // Shared knob padding style for both sliders.
+        let knob_pad_style = Style::new(|s| {
+            s.pad_all(2);
+        });
 
         // P1 label + slider
         let p1_label = Label::new(&cont)?;
@@ -92,7 +100,7 @@ impl View for Anim3 {
 
         let p1_slider = Slider::new(&cont)?;
         p1_slider.set_range(0, 1024);
-        p1_slider.style_pad_all(2, Part::Knob);
+        p1_slider.add_style(&knob_pad_style, Part::Knob);
         p1_slider.bubble_events();
         p1_slider.set_grid_cell(
             GridCell::new(GridAlign::Stretch, 1, 1),
@@ -106,7 +114,7 @@ impl View for Anim3 {
 
         let p2_slider = Slider::new(&cont)?;
         p2_slider.set_range(0, 1024);
-        p2_slider.style_pad_all(2, Part::Knob);
+        p2_slider.add_style(&knob_pad_style, Part::Knob);
         p2_slider.bubble_events();
         p2_slider.set_grid_cell(
             GridCell::new(GridAlign::Stretch, 1, 1),
@@ -125,8 +133,14 @@ impl View for Anim3 {
 
         // Chart
         let chart = Chart::new(&cont)?;
-        chart.pad(0);
-        chart.style_size(2, 2, Part::Indicator);
+        let chart_style = Style::new(|s| {
+            s.pad_all(0);
+        });
+        chart.add_style(&chart_style, Selector::DEFAULT);
+        let chart_indicator_style = Style::new(|s| {
+            s.size(2, 2);
+        });
+        chart.add_style(&chart_indicator_style, Part::Indicator);
         chart.set_type(ChartType::Scatter);
         let series = chart.add_series(palette_main(Palette::Red), ChartAxis::PrimaryY);
         chart.set_axis_range(ChartAxis::PrimaryY, 0, 1024);

--- a/examples/flex6.rs
+++ b/examples/flex6.rs
@@ -7,7 +7,7 @@
 //! Flex 6 — RTL base direction changes order of the items
 
 use oxivgl::{
-    style::{Selector, LV_SIZE_CONTENT},
+    style::{Selector, Style, LV_SIZE_CONTENT},
     view::{NavAction, View},
     layout::FlexFlow,
     widgets::{BaseDir, Label, Obj, WidgetError},
@@ -24,7 +24,10 @@ impl View for Flex6 {
     fn create(&mut self, container: &Obj<'static>) -> Result<(), WidgetError> {
 
         let cont = Obj::new(container)?;
-        cont.style_base_dir(BaseDir::Rtl, Selector::DEFAULT);
+        let cont_style = Style::new(|s| {
+            s.base_dir(BaseDir::Rtl);
+        });
+        cont.add_style(&cont_style, Selector::DEFAULT);
         cont.size(300, 220).center();
         cont.set_flex_flow(FlexFlow::RowWrap);
 

--- a/examples/getting_started1.rs
+++ b/examples/getting_started1.rs
@@ -7,6 +7,7 @@
 //! Getting Started 1 — Hello World
 
 use oxivgl::{
+    style::{Selector, Style},
     view::{NavAction, View},
     widgets::{Obj, Align, Label, WidgetError},
 };
@@ -18,8 +19,10 @@ struct GettingStarted1 {
 
 impl View for GettingStarted1 {
     fn create(&mut self, container: &Obj<'static>) -> Result<(), WidgetError> {
-        container.bg_color(0x003a57).bg_opa(255);
-        container.text_color(0xffffff);
+        let container_style = Style::new(|s| {
+            s.bg_color_hex(0x003a57).bg_opa(255).text_color_hex(0xffffff);
+        });
+        container.add_style(&container_style, Selector::DEFAULT);
 
         let label = Label::new(container)?;
         label.text("Hello world").align(Align::Center, 0, 0);

--- a/examples/getting_started3.rs
+++ b/examples/getting_started3.rs
@@ -25,6 +25,7 @@ struct GettingStarted3 {
     _style_red: Option<Style>,
     _style_pressed: Option<Style>,
     _style_btn: Option<Style>,
+    _style_pill: Option<Style>,
 }
 
 impl View for GettingStarted3 {
@@ -54,6 +55,10 @@ impl View for GettingStarted3 {
             .bg_grad_color(palette_lighten(Palette::Red, 3));
         let style_red = style_red.build();
 
+        let mut style_pill = StyleBuilder::new();
+        style_pill.radius(RADIUS_MAX as i16);
+        let style_pill = style_pill.build();
+
         let btn1 = Button::new(container)?;
         btn1.remove_style_all().pos(10, 10).size(120, 50);
         btn1.add_style(&style_btn, Selector::DEFAULT);
@@ -67,7 +72,7 @@ impl View for GettingStarted3 {
         btn2.add_style(&style_btn, Selector::DEFAULT);
         btn2.add_style(&style_red, Selector::DEFAULT);
         btn2.add_style(&style_pressed, ObjState::PRESSED);
-        btn2.radius(RADIUS_MAX, Selector::DEFAULT);
+        btn2.add_style(&style_pill, Selector::DEFAULT);
 
         let lbl2 = Label::new(&btn2)?;
         lbl2.text("Button 2").center();
@@ -79,6 +84,7 @@ impl View for GettingStarted3 {
         self._style_red = Some(style_red);
         self._style_pressed = Some(style_pressed);
         self._style_btn = Some(style_btn);
+        self._style_pill = Some(style_pill);
         Ok(())
     }
 

--- a/examples/grad_1.rs
+++ b/examples/grad_1.rs
@@ -20,6 +20,8 @@ struct Grad1 {
     _obj: Option<Obj<'static>>,
     _bullet1: Option<Button<'static>>,
     _bullet2: Option<Button<'static>>,
+    _bullet1_style: Option<Style>,
+    _bullet2_style: Option<Style>,
     _style: Option<Style>, // last — drop after widgets that reference it
 }
 
@@ -45,20 +47,28 @@ impl View for Grad1 {
         obj.add_style(&style, Selector::DEFAULT);
 
         // Bullet 1: magenta at (20%, 50%)
+        let bullet1_style = Style::new(|s| {
+            s.bg_color_hex(0xff00ff).bg_opa(255);
+        });
         let bullet1 = Button::new(&obj)?;
         bullet1
             .size(15, 15)
             .align(Align::TopLeft, lv_pct(20), lv_pct(50));
-        bullet1.bg_color(0xff00ff).bg_opa(255);
+        bullet1.add_style(&bullet1_style, Selector::DEFAULT);
 
         // Bullet 2: yellow at (80%, 50%)
+        let bullet2_style = Style::new(|s| {
+            s.bg_color_hex(0xffff00).bg_opa(255);
+        });
         let bullet2 = Button::new(&obj)?;
         bullet2
             .size(15, 15)
             .align(Align::TopLeft, lv_pct(80), lv_pct(50));
-        bullet2.bg_color(0xffff00).bg_opa(255);
+        bullet2.add_style(&bullet2_style, Selector::DEFAULT);
 
                 self._style = Some(style);
+        self._bullet1_style = Some(bullet1_style);
+        self._bullet2_style = Some(bullet2_style);
         self._obj = Some(obj);
         self._bullet1 = Some(bullet1);
         self._bullet2 = Some(bullet2);

--- a/examples/grad_2.rs
+++ b/examples/grad_2.rs
@@ -20,6 +20,8 @@ struct Grad2 {
     _obj: Option<Obj<'static>>,
     _bullet1: Option<Button<'static>>,
     _bullet2: Option<Button<'static>>,
+    _bullet1_style: Option<Style>,
+    _bullet2_style: Option<Style>,
     _style: Option<Style>, // last — drop after widgets that reference it
 }
 
@@ -45,16 +47,24 @@ impl View for Grad2 {
         obj.add_style(&style, Selector::DEFAULT);
 
         // Bullet 1: blue at (100, 100)
+        let bullet1_style = Style::new(|s| {
+            s.bg_color_hex(0x0000ff).bg_opa(255);
+        });
         let bullet1 = Button::new(&obj)?;
         bullet1.size(15, 15).pos(100, 100);
-        bullet1.bg_color(0x0000ff).bg_opa(255);
+        bullet1.add_style(&bullet1_style, Selector::DEFAULT);
 
         // Bullet 2: cyan at (200, 150)
+        let bullet2_style = Style::new(|s| {
+            s.bg_color_hex(0x00ffff).bg_opa(255);
+        });
         let bullet2 = Button::new(&obj)?;
         bullet2.size(15, 15).pos(200, 150);
-        bullet2.bg_color(0x00ffff).bg_opa(255);
+        bullet2.add_style(&bullet2_style, Selector::DEFAULT);
 
                 self._style = Some(style);
+        self._bullet1_style = Some(bullet1_style);
+        self._bullet2_style = Some(bullet2_style);
         self._obj = Some(obj);
         self._bullet1 = Some(bullet1);
         self._bullet2 = Some(bullet2);

--- a/examples/grad_3.rs
+++ b/examples/grad_3.rs
@@ -20,6 +20,8 @@ struct Grad3 {
     _obj: Option<Obj<'static>>,
     _bullet1: Option<Button<'static>>,
     _bullet2: Option<Button<'static>>,
+    _bullet1_style: Option<Style>,
+    _bullet2_style: Option<Style>,
     _style: Option<Style>, // last — drop after widgets that reference it
 }
 
@@ -46,16 +48,24 @@ impl View for Grad3 {
         obj.add_style(&style, Selector::DEFAULT);
 
         // Bullet 1: blue at (50, 50) — focal point
+        let bullet1_style = Style::new(|s| {
+            s.bg_color_hex(0x0000ff).bg_opa(255);
+        });
         let bullet1 = Button::new(&obj)?;
         bullet1.size(15, 15).pos(50, 50);
-        bullet1.bg_color(0x0000ff).bg_opa(255);
+        bullet1.add_style(&bullet1_style, Selector::DEFAULT);
 
         // Bullet 2: cyan at (100, 100) — center
+        let bullet2_style = Style::new(|s| {
+            s.bg_color_hex(0x00ffff).bg_opa(255);
+        });
         let bullet2 = Button::new(&obj)?;
         bullet2.size(15, 15).pos(100, 100);
-        bullet2.bg_color(0x00ffff).bg_opa(255);
+        bullet2.add_style(&bullet2_style, Selector::DEFAULT);
 
                 self._style = Some(style);
+        self._bullet1_style = Some(bullet1_style);
+        self._bullet2_style = Some(bullet2_style);
         self._obj = Some(obj);
         self._bullet1 = Some(bullet1);
         self._bullet2 = Some(bullet2);

--- a/examples/grad_4.rs
+++ b/examples/grad_4.rs
@@ -20,6 +20,8 @@ struct Grad4 {
     _obj: Option<Obj<'static>>,
     _bullet1: Option<Button<'static>>,
     _bullet2: Option<Button<'static>>,
+    _bullet1_style: Option<Style>,
+    _bullet2_style: Option<Style>,
     _style: Option<Style>, // last — drop after widgets that reference it
 }
 
@@ -45,20 +47,28 @@ impl View for Grad4 {
         obj.add_style(&style, Selector::DEFAULT);
 
         // Bullet 1: blue at (80%, 50%)
+        let bullet1_style = Style::new(|s| {
+            s.bg_color_hex(0x0000ff).bg_opa(255);
+        });
         let bullet1 = Button::new(&obj)?;
         bullet1
             .size(15, 15)
             .align(Align::TopLeft, lv_pct(80), lv_pct(50));
-        bullet1.bg_color(0x0000ff).bg_opa(255);
+        bullet1.add_style(&bullet1_style, Selector::DEFAULT);
 
         // Bullet 2: cyan at (20%, 50%)
+        let bullet2_style = Style::new(|s| {
+            s.bg_color_hex(0x00ffff).bg_opa(255);
+        });
         let bullet2 = Button::new(&obj)?;
         bullet2
             .size(15, 15)
             .align(Align::TopLeft, lv_pct(20), lv_pct(50));
-        bullet2.bg_color(0x00ffff).bg_opa(255);
+        bullet2.add_style(&bullet2_style, Selector::DEFAULT);
 
                 self._style = Some(style);
+        self._bullet1_style = Some(bullet1_style);
+        self._bullet2_style = Some(bullet2_style);
         self._obj = Some(obj);
         self._bullet1 = Some(bullet1);
         self._bullet2 = Some(bullet2);

--- a/examples/grid6.rs
+++ b/examples/grid6.rs
@@ -7,7 +7,7 @@
 //! Grid 6 — Demonstrate RTL direction on grid
 
 use oxivgl::{
-    style::Selector,
+    style::{Selector, Style},
     view::{NavAction, View},
     layout::{GridAlign, GridCell, GRID_TEMPLATE_LAST},
     widgets::{BaseDir, Label, Obj, WidgetError},
@@ -28,7 +28,10 @@ impl View for Grid6 {
 
         let cont = Obj::new(container)?;
         cont.size(300, 220).center();
-        cont.style_base_dir(BaseDir::Rtl, Selector::DEFAULT);
+        let cont_style = Style::new(|s| {
+            s.base_dir(BaseDir::Rtl);
+        });
+        cont.add_style(&cont_style, Selector::DEFAULT);
         cont.set_grid_dsc_array(&COL_DSC, &ROW_DSC);
 
         let mut items = heapless::Vec::<Obj<'static>, 9>::new();

--- a/examples/gridnav_1.rs
+++ b/examples/gridnav_1.rs
@@ -16,7 +16,7 @@ use oxivgl::{
     gridnav::{GridnavCtrl, gridnav_add},
     group::{Group, group_remove_obj},
     layout::FlexFlow,
-    style::{LV_SIZE_CONTENT, Palette, lv_pct, palette_lighten},
+    style::{LV_SIZE_CONTENT, Palette, Style, lv_pct, palette_lighten},
     view::{NavAction, View},
     widgets::{Align, Button, Checkbox, Label, Obj, Switch, Textarea, WidgetError},
 };
@@ -40,15 +40,17 @@ struct Gridnav1 {
 impl View for Gridnav1 {
     fn create(&mut self, container: &Obj<'static>) -> Result<(), WidgetError> {
 
+        // Shared focused-background style for both containers.
+        let focused_bg = Style::new(|s| {
+            s.bg_color(palette_lighten(Palette::Blue, 5));
+        });
+
         // ── Container 1: buttons, no rollover ──────────────────────────────
         let cont1 = oxivgl::widgets::Obj::new(container)?;
         cont1
             .set_flex_flow(FlexFlow::RowWrap)
-            .style_bg_color(
-                palette_lighten(Palette::Blue, 5),
-                ObjState::FOCUSED,
-            )
             .size(lv_pct(50), lv_pct(100));
+        cont1.add_style(&focused_bg, ObjState::FOCUSED);
 
         gridnav_add(&cont1, GridnavCtrl::NONE);
 
@@ -79,12 +81,9 @@ impl View for Gridnav1 {
         // ── Container 2: textarea/checkbox/switches, rollover ──────────────
         let cont2 = oxivgl::widgets::Obj::new(container)?;
         cont2
-            .style_bg_color(
-                palette_lighten(Palette::Blue, 5),
-                ObjState::FOCUSED,
-            )
             .size(lv_pct(50), lv_pct(100))
             .align(Align::RightMid, 0, 0);
+        cont2.add_style(&focused_bg, ObjState::FOCUSED);
 
         gridnav_add(&cont2, GridnavCtrl::ROLLOVER);
 

--- a/examples/gridnav_2.rs
+++ b/examples/gridnav_2.rs
@@ -14,7 +14,7 @@ use oxivgl::{
     enums::ObjState,
     gridnav::{GridnavCtrl, gridnav_add},
     group::{Group, group_remove_obj},
-    style::{Palette, lv_pct, palette_lighten},
+    style::{Palette, Style, lv_pct, palette_lighten},
     symbols,
     view::{NavAction, View},
     widgets::{Obj, Align, List, WidgetError},
@@ -25,17 +25,27 @@ struct Gridnav2 {
     _group: Option<Group>,
     _list1: Option<List<'static>>,
     _list2: Option<List<'static>>,
+    _focus_style: Option<Style>,
+    _item_style: Option<Style>,
 }
 
 impl View for Gridnav2 {
     fn create(&mut self, container: &Obj<'static>) -> Result<(), WidgetError> {
+
+        // Shared styles: list focus background and transparent list-item bg.
+        let focus_style = Style::new(|s| {
+            s.bg_color(palette_lighten(Palette::Blue, 5));
+        });
+        let item_style = Style::new(|s| {
+            s.bg_opa(0);
+        });
 
         // ── List 1: File items, no rollover ───────────────────────────────
         let list1 = List::new(container)?;
         list1
             .size(lv_pct(45), lv_pct(80))
             .align(Align::LeftMid, 5, 0)
-            .style_bg_color(palette_lighten(Palette::Blue, 5), ObjState::FOCUSED);
+            .add_style(&focus_style, ObjState::FOCUSED);
 
         gridnav_add(&list1, GridnavCtrl::NONE);
 
@@ -43,7 +53,7 @@ impl View for Gridnav2 {
             let mut buf = heapless::String::<16>::new();
             let _ = core::fmt::Write::write_fmt(&mut buf, format_args!("File {}", i));
             let item = list1.add_button(Some(&symbols::FILE), &buf);
-            item.bg_opa_selector(0, ObjState::DEFAULT);
+            item.add_style(&item_style, ObjState::DEFAULT);
             group_remove_obj(&item);
         }
 
@@ -52,7 +62,7 @@ impl View for Gridnav2 {
         list2
             .size(lv_pct(45), lv_pct(80))
             .align(Align::RightMid, -5, 0)
-            .style_bg_color(palette_lighten(Palette::Blue, 5), ObjState::FOCUSED);
+            .add_style(&focus_style, ObjState::FOCUSED);
 
         gridnav_add(&list2, GridnavCtrl::ROLLOVER);
 
@@ -60,7 +70,7 @@ impl View for Gridnav2 {
             let mut buf = heapless::String::<16>::new();
             let _ = core::fmt::Write::write_fmt(&mut buf, format_args!("Folder {}", i));
             let item = list2.add_button(Some(&symbols::DIRECTORY), &buf);
-            item.bg_opa_selector(0, ObjState::DEFAULT);
+            item.add_style(&item_style, ObjState::DEFAULT);
             group_remove_obj(&item);
         }
 
@@ -74,6 +84,8 @@ impl View for Gridnav2 {
         self._group = Some(group);
         self._list1 = Some(list1);
         self._list2 = Some(list2);
+        self._focus_style = Some(focus_style);
+        self._item_style = Some(item_style);
         Ok(())
     }
 

--- a/examples/gridnav_3.rs
+++ b/examples/gridnav_3.rs
@@ -21,7 +21,7 @@ use oxivgl::{
     gridnav::{GridnavCtrl, gridnav_add},
     group::{Group, group_remove_obj},
     layout::FlexFlow,
-    style::{LV_SIZE_CONTENT, Palette, lv_pct, palette_lighten},
+    style::{LV_SIZE_CONTENT, Palette, Style, lv_pct, palette_lighten},
     view::{View, register_event_on},
     widgets::{Button, Label, Obj, WidgetError},
 };
@@ -49,12 +49,21 @@ struct Gridnav3 {
 impl View for Gridnav3 {
     fn create(&mut self, container: &Obj<'static>) -> Result<(), WidgetError> {
 
+        // Shared focused-background styles (one per color, reused across
+        // containers for memory efficiency).
+        let focus_blue = Style::new(|s| {
+            s.bg_color(palette_lighten(Palette::Blue, 5));
+        });
+        let focus_red = Style::new(|s| {
+            s.bg_color(palette_lighten(Palette::Red, 5));
+        });
+
         // ── Main container ────────────────────────────────────────────────
         let cont_main = Obj::new(container)?;
         cont_main
             .set_flex_flow(FlexFlow::RowWrap)
-            .style_bg_color(palette_lighten(Palette::Blue, 5), ObjState::FOCUSED)
             .size(lv_pct(80), LV_SIZE_CONTENT);
+        cont_main.add_style(&focus_blue, ObjState::FOCUSED);
 
         gridnav_add(&cont_main, GridnavCtrl::ROLLOVER | GridnavCtrl::SCROLL_FIRST);
 
@@ -76,9 +85,8 @@ impl View for Gridnav3 {
 
         // ── Sub-container 1: long scrollable text ────────────────────────
         let cont_sub1 = Obj::new(&cont_main)?;
-        cont_sub1
-            .style_bg_color(palette_lighten(Palette::Red, 5), ObjState::FOCUSED)
-            .size(lv_pct(100), 100);
+        cont_sub1.size(lv_pct(100), 100);
+        cont_sub1.add_style(&focus_red, ObjState::FOCUSED);
 
         let sub1_lbl = Label::new(&cont_sub1)?;
         sub1_lbl.width(lv_pct(100));
@@ -99,8 +107,8 @@ impl View for Gridnav3 {
         let cont_sub2 = Obj::new(&cont_main)?;
         cont_sub2
             .set_flex_flow(FlexFlow::RowWrap)
-            .style_bg_color(palette_lighten(Palette::Red, 5), ObjState::FOCUSED)
             .size(lv_pct(100), LV_SIZE_CONTENT);
+        cont_sub2.add_style(&focus_red, ObjState::FOCUSED);
 
         gridnav_add(&cont_sub2, GridnavCtrl::ROLLOVER);
         group.add_obj(&cont_sub2);

--- a/examples/list_2.rs
+++ b/examples/list_2.rs
@@ -22,7 +22,7 @@ use oxivgl::{
     gridnav::{GridnavCtrl, gridnav_add},
     group::{Group, group_remove_obj},
     layout::FlexFlow,
-    style::lv_pct,
+    style::{lv_pct, Style},
     symbols,
     view::{View, register_event_on},
     widgets::{Obj, Align, Button, Label, List, Part, WidgetError},
@@ -45,9 +45,11 @@ impl View for List2 {
 
         // ── Left list: 15 plain buttons ───────────────────────────────────
         let list1 = List::new(container)?;
-        list1
-            .size(lv_pct(60), lv_pct(100))
-            .style_pad_row(5, Part::Main);
+        list1.size(lv_pct(60), lv_pct(100));
+        let list1_style = Style::new(|s| {
+            s.pad_row(5);
+        });
+        list1.add_style(&list1_style, Part::Main);
         gridnav_add(&list1, GridnavCtrl::ROLLOVER);
 
         let mut item_labels: heapless::Vec<Label<'static>, 15> = heapless::Vec::new();

--- a/examples/observer3.rs
+++ b/examples/observer3.rs
@@ -24,7 +24,7 @@ use oxivgl::{
     enums::{EventCode, ObjFlag, ObjState},
     event::Event,
     fonts::MONTSERRAT_30,
-    style::{LV_SIZE_CONTENT, lv_pct},
+    style::{LV_SIZE_CONTENT, Selector, Style, lv_pct},
     view::{NavAction, View},
     widgets::{Align, AsLvHandle, Button, Child, Dropdown, Label, Obj, Roller, RollerMode, Screen, Subject, WidgetError},
 };
@@ -52,6 +52,7 @@ struct Observer3 {
     hour_roller: Option<Child<Roller<'static>>>,
     close_btn_handle: *mut c_void,
     last_format: i32,
+    _time_label_style: Option<Style>,
     // Subjects last — drop after widgets so observers removed before deinit.
     hour_subject: Option<Subject>,
     minute_subject: Option<Subject>,
@@ -77,7 +78,11 @@ impl View for Observer3 {
 
         // Time display label.
         let time_label = Label::new(container)?;
-        time_label.text_font(MONTSERRAT_30).pos(24, 24);
+        let time_label_style = Style::new(|s| {
+            s.text_font(MONTSERRAT_30);
+        });
+        time_label.add_style(&time_label_style, Selector::DEFAULT);
+        time_label.pos(24, 24);
 
         // Set button — opens the settings panel.
         let set_btn = Button::new(container)?;
@@ -96,6 +101,7 @@ impl View for Observer3 {
         self.hour_roller = None;
         self.close_btn_handle = null_mut();
         self.last_format = TIME_FORMAT_12;
+        self._time_label_style = Some(time_label_style);
         self.hour_subject = Some(hour_subject);
         self.minute_subject = Some(minute_subject);
         self.format_subject = Some(format_subject);

--- a/examples/observer4.rs
+++ b/examples/observer4.rs
@@ -23,7 +23,7 @@ use oxivgl::{
     enums::{EventCode, ObjFlag, ObjState, ScrollDir},
     event::Event,
     layout::{FlexAlign, FlexFlow},
-    style::{Selector, lv_pct},
+    style::{Selector, Style, lv_pct},
     view::{NavAction, View},
     widgets::{Align, AsLvHandle, Button, Child, Dropdown, Label, Obj, Roller, RollerMode, Slider, Subject, WidgetError},
 };
@@ -69,31 +69,49 @@ impl View for Observer4 {
             Subject::new_int(2),
         ];
 
+        // Shared styles.
+        let pad0_style = Style::new(|s| {
+            s.pad_all(0);
+        });
+        // pad_all(8) is shared by the content area and footer.
+        let pad8_style = Style::new(|s| {
+            s.pad_all(8);
+        });
+        let btn_radius_style = Style::new(|s| {
+            s.radius(0);
+        });
+        let indicator_style = Style::new(|s| {
+            s.bg_opa(102); // 40% of 255 ≈ 102
+        });
+
         // Main container — full screen, flex column.
         let main_cont = Obj::new(container)?;
         main_cont
             .remove_style_all()
             .size(lv_pct(100), lv_pct(100))
-            .pad(0)
             .set_flex_flow(FlexFlow::Column);
+        main_cont.add_style(&pad0_style, Selector::DEFAULT);
 
         // Content area — flex-grow 1, scrollable vertically.
         let cont = Obj::new(&main_cont)?;
         cont.remove_style_all()
             .set_flex_grow(1)
-            .pad(8)
             .width(lv_pct(100))
             .set_scroll_dir(ScrollDir::VER);
+        cont.add_style(&pad8_style, Selector::DEFAULT);
 
         // Footer — 60px tall, row layout with buttons.
         let footer = Obj::new(&main_cont)?;
         footer
             .remove_style_all()
             .size(lv_pct(100), 60)
-            .style_pad_column(8, Selector::DEFAULT)
-            .pad(8)
             .set_flex_flow(FlexFlow::Row)
             .set_flex_align(FlexAlign::Center, FlexAlign::Center, FlexAlign::Center);
+        let footer_pad_column_style = Style::new(|s| {
+            s.pad_column(8);
+        });
+        footer.add_style(&footer_pad_column_style, Selector::DEFAULT);
+        footer.add_style(&pad8_style, Selector::DEFAULT);
 
         // Three tab buttons.
         let btn_labels = ["First", "Second", "Third"];
@@ -103,8 +121,8 @@ impl View for Observer4 {
             let btn = Child::new(Button::new(&footer)?);
             btn.set_flex_grow(1)
                 .height(lv_pct(100))
-                .radius(0, Selector::DEFAULT)
                 .bubble_events();
+            btn.add_style(&btn_radius_style, Selector::DEFAULT);
             btn.bind_state_if_eq(&tab_subject, ObjState::CHECKED, i as i32);
 
             let lbl = Child::new(Label::new(&*btn)?);
@@ -117,10 +135,10 @@ impl View for Observer4 {
         let indicator = Obj::new(&footer)?;
         indicator
             .remove_style(None, Selector::DEFAULT)
-            .bg_opa(102) // 40% of 255 ≈ 102
             .height(10)
             .align(Align::BottomLeft, 0, 0)
             .add_flag(ObjFlag::IGNORE_LAYOUT);
+        indicator.add_style(&indicator_style, Selector::DEFAULT);
 
         // Force layout so we can read button positions for the initial indicator.
         indicator.update_layout();

--- a/examples/observer5.rs
+++ b/examples/observer5.rs
@@ -17,7 +17,7 @@ use core::ptr::null_mut;
 use oxivgl::{
     enums::{EventCode, ObjFlag},
     event::Event,
-    style::{Selector, color_make},
+    style::{Selector, Style, color_make},
     timer::Timer,
     view::{NavAction, View},
     widgets::{
@@ -102,11 +102,14 @@ impl View for Observer5 {
 
             // Style: rounded corners + drop shadow.
             let shadow_color = color_make(0x88, 0x88, 0x88);
-            win.radius(8, Selector::DEFAULT)
-                .style_shadow_width(24, Selector::DEFAULT)
-                .style_shadow_offset_x(2, Selector::DEFAULT)
-                .style_shadow_offset_y(3, Selector::DEFAULT)
-                .style_shadow_color(shadow_color, Selector::DEFAULT);
+            let win_style = Style::new(|s| {
+                s.radius(8)
+                    .shadow_width(24)
+                    .shadow_offset_x(2)
+                    .shadow_offset_y(3)
+                    .shadow_color(shadow_color);
+            });
+            win.add_style(&win_style, Selector::DEFAULT);
 
             // Title and close button in the header.
             win.add_title("Firmware update");

--- a/examples/scroll3.rs
+++ b/examples/scroll3.rs
@@ -12,7 +12,7 @@
 use oxivgl::{
     enums::{EventCode, ObjFlag},
     event::Event,
-    style::Selector,
+    style::{Selector, Style},
     symbols,
     view::{NavAction, View},
     widgets::{Obj, Align, Button, List, Part, WidgetError, RADIUS_MAX},
@@ -23,6 +23,7 @@ struct Scroll3 {
     list: Option<List<'static>>,
     float_btn: Option<Button<'static>>,
     btn_cnt: u32,
+    _float_btn_style: Option<Style>,
 }
 
 impl View for Scroll3 {
@@ -45,12 +46,16 @@ impl View for Scroll3 {
         let pad = list.get_style_pad_right(Part::Main);
         float_btn.align(Align::BottomRight, 0, -pad);
         float_btn.bubble_events();
-        float_btn.radius(RADIUS_MAX, Selector::DEFAULT);
+        let float_btn_style = Style::new(|s| {
+            s.radius(RADIUS_MAX as i16);
+        });
+        float_btn.add_style(&float_btn_style, Selector::DEFAULT);
         float_btn.style_bg_image_src_symbol(&symbols::PLUS, Selector::DEFAULT);
 
                 self.list = Some(list);
         self.float_btn = Some(float_btn);
         self.btn_cnt = 2;
+        self._float_btn_style = Some(float_btn_style);
         Ok(())
     }
 

--- a/examples/scroll5.rs
+++ b/examples/scroll5.rs
@@ -11,7 +11,7 @@
 
 use oxivgl::{
     fonts::DEJAVU_16_PERSIAN_HEBREW,
-    style::Selector,
+    style::{Selector, Style},
     view::{NavAction, View},
     widgets::{BaseDir, Label, Obj, WidgetError},
 };
@@ -26,14 +26,21 @@ impl View for Scroll5 {
     fn create(&mut self, container: &Obj<'static>) -> Result<(), WidgetError> {
 
         let cont = Obj::new(container)?;
-        cont.style_base_dir(BaseDir::Rtl, Selector::DEFAULT);
+        let cont_style = Style::new(|s| {
+            s.base_dir(BaseDir::Rtl);
+        });
+        cont.add_style(&cont_style, Selector::DEFAULT);
         cont.size(200, 100);
         cont.center();
+
+        let font_style = Style::new(|s| {
+            s.text_font(DEJAVU_16_PERSIAN_HEBREW);
+        });
 
         let label = Label::new(&cont)?;
         label.text("به وسیله یک ماشین نوشته شده است");
         label.width(400);
-        label.style_text_font(DEJAVU_16_PERSIAN_HEBREW, Selector::DEFAULT);
+        label.add_style(&font_style, Selector::DEFAULT);
 
         self._cont = Some(cont);
         self._label = Some(label);

--- a/examples/scroll6.rs
+++ b/examples/scroll6.rs
@@ -20,7 +20,7 @@ use oxivgl::{
     event::Event,
     layout::FlexFlow,
     math::map,
-    style::{lv_pct, Selector},
+    style::{lv_pct, Selector, Style},
     view::{register_event_on, View},
     widgets::{Button, Label, Obj, WidgetError, RADIUS_MAX},
 };
@@ -28,6 +28,7 @@ use oxivgl::{
 #[derive(Default)]
 struct Scroll6 {
     cont: Option<Obj<'static>>,
+    _cont_style: Option<Style>,
 }
 
 impl View for Scroll6 {
@@ -36,8 +37,10 @@ impl View for Scroll6 {
         let cont = Obj::new(container)?;
         cont.size(200, 200).center();
         cont.set_flex_flow(FlexFlow::Column);
-        cont.style_clip_corner(true, Selector::DEFAULT);
-        cont.radius(RADIUS_MAX, Selector::DEFAULT);
+        let cont_style = Style::new(|s| {
+            s.radius(RADIUS_MAX as i16).clip_corner(true);
+        });
+        cont.add_style(&cont_style, Selector::DEFAULT);
         cont.set_scroll_dir(ScrollDir::VER);
         cont.set_scroll_snap_y(ScrollSnap::Center);
         cont.set_scrollbar_mode(ScrollbarMode::Off);
@@ -58,6 +61,7 @@ impl View for Scroll6 {
         }
 
                 self.cont = Some(cont);
+        self._cont_style = Some(cont_style);
         Ok(())
     }
 
@@ -97,6 +101,8 @@ impl View for Scroll6 {
             };
             child.style_translate_x(x, Selector::DEFAULT);
             let opa = map(x, 0, r, 0, 255) as u8;
+            #[allow(deprecated)]
+            // runtime-varying style; must stay inline
             child.style_opa(255 - opa, Selector::DEFAULT);
         }
         NavAction::None

--- a/examples/scroll7.rs
+++ b/examples/scroll7.rs
@@ -15,7 +15,7 @@ use oxivgl::{
     enums::{EventCode, ObjState},
     event::Event,
     layout::FlexFlow,
-    style::lv_pct,
+    style::{lv_pct, Style},
     view::{register_event_on, View},
     widgets::{Align, Checkbox, Label, Obj, Part, WidgetError},
 };
@@ -135,7 +135,12 @@ impl View for Scroll7 {
         cont.size(160, 220);
         cont.align(Align::RightMid, -10, 0);
         cont.set_flex_flow(FlexFlow::Column);
-        cont.style_opa(0, Part::Scrollbar);
+        // Hide the scrollbar initially via a shared style; the checkbox handler
+        // overrides the opacity at runtime with a local style (last-wins).
+        let scrollbar_hidden = Style::new(|s| {
+            s.opa(0);
+        });
+        cont.add_style(&scrollbar_hidden, Part::Scrollbar);
 
         // Load initial item
         let item = Obj::new(&cont)?;
@@ -174,6 +179,8 @@ impl View for Scroll7 {
                 let checked = checkbox.has_state(ObjState::CHECKED);
                 let opa = if checked { 255u8 } else { 0u8 };
                 if let Some(ref cont) = self.cont {
+                    #[allow(deprecated)]
+                    // runtime-varying style; must stay inline
                     cont.style_opa(opa, Part::Scrollbar);
                 }
             }

--- a/examples/scroll9.rs
+++ b/examples/scroll9.rs
@@ -15,6 +15,7 @@ use alloc::vec::Vec;
 
 use oxivgl::{
     enums::ObjFlag,
+    style::{Selector, Style},
     view::{NavAction, View},
     widgets::{Align, Label, Obj, Switch, WidgetError},
 };
@@ -34,16 +35,31 @@ struct Scroll9 {
     _switches: Option<Vec<Switch<'static>>>,
     _labels: Option<Vec<Label<'static>>>,
     _children: Option<Vec<Obj<'static>>>,
+    _styles: Option<Vec<Style>>,
 }
 
 impl View for Scroll9 {
     fn create(&mut self, container: &Obj<'static>) -> Result<(), WidgetError> {
 
+        // Shared styles: one panel background, plus one per child color
+        // (each combining bg_color + bg_opa) reused across the 20 children.
+        let panel_style = Style::new(|s| {
+            s.bg_color_hex(0xeeeeee);
+        });
+        let child_styles: Vec<Style> = COLORS
+            .iter()
+            .map(|&c| {
+                Style::new(move |s| {
+                    s.bg_color_hex(c).bg_opa(255);
+                })
+            })
+            .collect();
+
         // Scrollable panel
         let panel = Obj::new(container)?;
         panel.size(200, 120);
         panel.align(Align::TopMid, 0, 5);
-        panel.bg_color(0xeeeeee);
+        panel.add_style(&panel_style, Selector::DEFAULT);
 
         // 20 colored children in a grid that exceeds panel bounds
         let mut children = Vec::with_capacity(20);
@@ -55,11 +71,13 @@ impl View for Scroll9 {
             let x = 10 + col * (CHILD_W + GAP);
             let y = 10 + row * (CHILD_H + GAP);
             child.pos(x, y);
-            child.bg_color(COLORS[i % COLORS.len()]);
-            child.bg_opa(255);
+            child.add_style(&child_styles[i % COLORS.len()], Selector::DEFAULT);
             child.remove_flag(ObjFlag::SCROLLABLE);
             children.push(child);
         }
+
+        let mut styles = child_styles;
+        styles.push(panel_style);
 
         // Switch labels
         let flag_names = ["Scrollable", "Chain", "Elastic", "Momentum"];
@@ -84,6 +102,7 @@ impl View for Scroll9 {
         self._switches = Some(switches);
         self._labels = Some(labels);
         self._children = Some(children);
+        self._styles = Some(styles);
         Ok(())
     }
 

--- a/examples/snapshot_1.rs
+++ b/examples/snapshot_1.rs
@@ -13,8 +13,9 @@
 use oxivgl::{
     layout::{FlexAlign, FlexFlow},
     snapshot::Snapshot,
+    style::{Selector, Style},
     view::{NavAction, View},
-    widgets::{Image, Obj, Part, WidgetError},
+    widgets::{Image, Obj, WidgetError},
 };
 
 #[derive(Default)]
@@ -35,7 +36,11 @@ const ITEM_COLORS: [u32; 4] = [0xe74c3c, 0x2ecc71, 0x3498db, 0xf39c12];
 
 impl View for Snapshot1 {
     fn create(&mut self, container: &Obj<'static>) -> Result<(), WidgetError> {
-        container.bg_color(0xadd8e6).bg_opa(255);
+        // Shared background style for the root screen container.
+        let screen_style = Style::new(|s| {
+            s.bg_color_hex(0xadd8e6).bg_opa(255);
+        });
+        container.add_style(&screen_style, Selector::DEFAULT);
 
         // Image widget that will display the snapshot (source set later).
         let snapshot_img = Image::new(container)?;
@@ -43,25 +48,33 @@ impl View for Snapshot1 {
 
         // Container: 180×180, centered, flex row-wrap, radius 50.
         let container = Obj::new(container)?;
-        container
-            .size(180, 180)
-            .center()
-            .radius(50, Part::Main)
-            .bg_color(0x303030)
-            .bg_opa(255);
+        container.size(180, 180).center();
+        // Shared style: radius 50, dark background, pad 5.
+        let container_style = Style::new(|s| {
+            s.radius(50).bg_color_hex(0x303030).bg_opa(255).pad_all(5);
+        });
+        container.add_style(&container_style, Selector::DEFAULT);
         container.set_flex_flow(FlexFlow::RowWrap);
         container.set_flex_align(FlexAlign::SpaceEvenly, FlexAlign::Center, FlexAlign::Center);
-        container.pad(5);
 
-        // Four colored squares inside the container.
+        // Shared style for the four squares: opaque, no border.
+        let item_style = Style::new(|s| {
+            s.bg_opa(255).border_width(0);
+        });
+        // Four colored squares inside the container. The shared style carries
+        // the common opacity/border; each item gets its own bg color.
         let item0 = Obj::new(&container)?;
-        item0.size(50, 50).bg_color(ITEM_COLORS[0]).bg_opa(255).border_width(0);
+        item0.size(50, 50).add_style(&item_style, Selector::DEFAULT);
+        item0.add_style(&Style::new(|s| { s.bg_color_hex(ITEM_COLORS[0]); }), Selector::DEFAULT);
         let item1 = Obj::new(&container)?;
-        item1.size(50, 50).bg_color(ITEM_COLORS[1]).bg_opa(255).border_width(0);
+        item1.size(50, 50).add_style(&item_style, Selector::DEFAULT);
+        item1.add_style(&Style::new(|s| { s.bg_color_hex(ITEM_COLORS[1]); }), Selector::DEFAULT);
         let item2 = Obj::new(&container)?;
-        item2.size(50, 50).bg_color(ITEM_COLORS[2]).bg_opa(255).border_width(0);
+        item2.size(50, 50).add_style(&item_style, Selector::DEFAULT);
+        item2.add_style(&Style::new(|s| { s.bg_color_hex(ITEM_COLORS[2]); }), Selector::DEFAULT);
         let item3 = Obj::new(&container)?;
-        item3.size(50, 50).bg_color(ITEM_COLORS[3]).bg_opa(255).border_width(0);
+        item3.size(50, 50).add_style(&item_style, Selector::DEFAULT);
+        item3.add_style(&Style::new(|s| { s.bg_color_hex(ITEM_COLORS[3]); }), Selector::DEFAULT);
 
         // Take snapshot of the container (ARGB8888).
         let snapshot = Snapshot::take_widget(&container).ok_or(WidgetError::LvglNullPointer)?;

--- a/examples/style12.rs
+++ b/examples/style12.rs
@@ -18,6 +18,7 @@ use oxivgl::{
 struct Style12 {
     _obj: Option<Obj<'static>>,
     _style: Option<Style>,
+    _style_bg: Option<Style>,
 }
 
 impl View for Style12 {
@@ -30,13 +31,19 @@ impl View for Style12 {
             .border_width(3);
         let style = builder.build();
 
+        // Applied after `style` so its bg_color wins (LVGL last-wins order).
+        let style_bg = Style::new(|s| {
+            s.bg_color(palette_main(Palette::Orange));
+        });
+
         let obj = Obj::new(container)?;
         obj.add_style(&style, Selector::DEFAULT);
-        obj.style_bg_color(palette_main(Palette::Orange), Selector::DEFAULT);
+        obj.add_style(&style_bg, Selector::DEFAULT);
         obj.center();
 
                 self._obj = Some(obj);
         self._style = Some(style);
+        self._style_bg = Some(style_bg);
         Ok(())
     }
 

--- a/examples/style15.rs
+++ b/examples/style15.rs
@@ -7,7 +7,7 @@
 //! Style 15 — Opacity and Transformations
 
 use oxivgl::{
-    style::Selector,
+    style::{Selector, Style},
     view::{NavAction, View},
     widgets::{Obj, Align, Button, Label, WidgetError},
 };
@@ -25,18 +25,25 @@ struct Style15 {
 impl View for Style15 {
     fn create(&mut self, container: &Obj<'static>) -> Result<(), WidgetError> {
 
+        // Shared opacity style (opa 50%) applied to the buttons that need it.
+        let opa_style = Style::new(|s| {
+            s.opa(128);
+        });
+
         let btn1 = Button::new(container)?;
         btn1.size(100, 40).align(Align::Center, 0, -70);
         let label1 = Label::new(&btn1)?;
         label1.text("Normal").center();
 
         let btn2 = Button::new(container)?;
-        btn2.size(100, 40).opa(128).align(Align::Center, 0, 0);
+        btn2.size(100, 40).align(Align::Center, 0, 0);
+        btn2.add_style(&opa_style, Selector::DEFAULT);
         let label2 = Label::new(&btn2)?;
         label2.text("Opa:50%").center();
 
         let btn3 = Button::new(container)?;
-        btn3.size(100, 40).opa(128).align(Align::Center, 0, 70);
+        btn3.size(100, 40).align(Align::Center, 0, 70);
+        btn3.add_style(&opa_style, Selector::DEFAULT);
         btn3.style_transform_rotation(150, Selector::DEFAULT)
             .style_transform_scale(256 + 64, Selector::DEFAULT)
             .style_transform_pivot_x(50, Selector::DEFAULT)

--- a/examples/style18.rs
+++ b/examples/style18.rs
@@ -24,6 +24,8 @@ struct Style18 {
     _btn1: Option<Button<'static>>,
     _style_radial: Option<Style>,
     _style_linear: Option<Style>,
+    _style_hor: Option<Style>,
+    _style_ver: Option<Style>,
 }
 
 impl View for Style18 {
@@ -57,19 +59,22 @@ impl View for Style18 {
         style_radial.bg_grad(grad_radial).bg_opa(255);
         let style_radial = style_radial.build();
 
+        let style_hor = Style::new(|s| {
+            s.bg_color(c0).bg_grad_color(c1).bg_grad_dir(GradDir::Hor);
+        });
+        let style_ver = Style::new(|s| {
+            s.bg_color(c0).bg_grad_color(c1).bg_grad_dir(GradDir::Ver);
+        });
+
         let btn1 = Button::new(container)?;
         btn1.size(150, 50).align(Align::Center, 0, -100);
-        btn1.style_bg_color(c0, Selector::DEFAULT);
-        btn1.style_bg_grad_color(c1, Selector::DEFAULT);
-        btn1.style_bg_grad_dir(GradDir::Hor, Selector::DEFAULT);
+        btn1.add_style(&style_hor, Selector::DEFAULT);
         let label1 = Label::new(&btn1)?;
         label1.text("Horizontal").center();
 
         let btn2 = Button::new(container)?;
         btn2.size(150, 50).align(Align::Center, 0, -40);
-        btn2.style_bg_color(c0, Selector::DEFAULT);
-        btn2.style_bg_grad_color(c1, Selector::DEFAULT);
-        btn2.style_bg_grad_dir(GradDir::Ver, Selector::DEFAULT);
+        btn2.add_style(&style_ver, Selector::DEFAULT);
         let label2 = Label::new(&btn2)?;
         label2.text("Vertical").center();
 
@@ -95,6 +100,8 @@ impl View for Style18 {
         self._btn1 = Some(btn1);
         self._style_radial = Some(style_radial);
         self._style_linear = Some(style_linear);
+        self._style_hor = Some(style_hor);
+        self._style_ver = Some(style_ver);
         Ok(())
     }
 

--- a/examples/style20.rs
+++ b/examples/style20.rs
@@ -10,7 +10,7 @@
 //! overlay is shown on top. For the screenshot the overlay is visible.
 
 use oxivgl::{
-    style::Selector,
+    style::{Selector, Style},
     view::{NavAction, View},
     widgets::{Align, Button, Label, Obj, WidgetError},
 };
@@ -27,8 +27,10 @@ struct Style20 {
 
 impl View for Style20 {
     fn create(&mut self, container: &Obj<'static>) -> Result<(), WidgetError> {
-        container.bg_color(0xffffff);
-        container.bg_opa(255);
+        let container_style = Style::new(|s| {
+            s.bg_color_hex(0xffffff).bg_opa(255);
+        });
+        container.add_style(&container_style, Selector::DEFAULT);
 
         // Two buttons
         let btn1 = Button::new(container)?;
@@ -49,15 +51,18 @@ impl View for Style20 {
         let overlay = Obj::new(container)?;
         overlay.size(320, 240);
         overlay.align(Align::Center, 0, 0);
-        overlay.bg_color(0x000000);
-        overlay.bg_opa(180);
-        overlay.border_width(0);
-        overlay.radius(0, Selector::DEFAULT);
+        let overlay_style = Style::new(|s| {
+            s.bg_color_hex(0x000000).bg_opa(180).border_width(0).radius(0);
+        });
+        overlay.add_style(&overlay_style, Selector::DEFAULT);
 
         let overlay_label = Label::new(&overlay)?;
         overlay_label.text("Modal overlay\nclick to dismiss");
         overlay_label.center();
-        overlay_label.text_color(0xffffff);
+        let overlay_label_style = Style::new(|s| {
+            s.text_color_hex(0xffffff);
+        });
+        overlay_label.add_style(&overlay_label_style, Selector::DEFAULT);
 
                 self._btn1 = Some(btn1);
         self._btn2 = Some(btn2);

--- a/examples/style21.rs
+++ b/examples/style21.rs
@@ -13,7 +13,7 @@ use oxivgl::{
     enums::EventCode,
     event::Event,
     layout::FlexFlow,
-    style::{color_make, Selector},
+    style::{color_make, Selector, Style},
     view::{NavAction, View},
     widgets::{Align, Arc, Label, Obj, Slider, WidgetError},
 };
@@ -32,21 +32,41 @@ struct Style21 {
 
 impl View for Style21 {
     fn create(&mut self, container: &Obj<'static>) -> Result<(), WidgetError> {
-        container.bg_color(0xeeeeee).bg_opa(255);
+        // Shared screen background style.
+        let bg_style = Style::new(|s| {
+            s.bg_color_hex(0xeeeeee).bg_opa(255);
+        });
+        container.add_style(&bg_style, Selector::DEFAULT);
+
+        // Shared card style — identical for both cards (one property buffer).
+        let card_style = Style::new(|s| {
+            s.bg_color_hex(0xffffff)
+                .bg_opa(255)
+                .radius(12)
+                .border_width(0)
+                .shadow_width(20)
+                .shadow_color(color_make(0x88, 0x88, 0x88))
+                .shadow_offset_x(2)
+                .shadow_offset_y(4)
+                .shadow_spread(0)
+                .shadow_opa(200);
+        });
+
+        // Shared transparent-row style — the two control rows.
+        let row_style = Style::new(|s| {
+            s.bg_opa(0).border_width(0);
+        });
+
+        // Controls container style — transparent like the rows, plus padding.
+        let controls_style = Style::new(|s| {
+            s.bg_opa(0).border_width(0).pad_all(4).pad_row(8);
+        });
 
         // --- Card 1 ---
         let card1 = Obj::new(container)?;
         card1.size(120, 80);
         card1.align(Align::TopLeft, 20, 20);
-        card1.bg_color(0xffffff).bg_opa(255);
-        card1.radius(12, Selector::DEFAULT);
-        card1.border_width(0);
-        card1.style_shadow_width(20, Selector::DEFAULT);
-        card1.style_shadow_color(color_make(0x88, 0x88, 0x88), Selector::DEFAULT);
-        card1.style_shadow_offset_x(2, Selector::DEFAULT);
-        card1.style_shadow_offset_y(4, Selector::DEFAULT);
-        card1.style_shadow_spread(0, Selector::DEFAULT);
-        card1.style_shadow_opa(200, Selector::DEFAULT);
+        card1.add_style(&card_style, Selector::DEFAULT);
         card1.style_transform_pivot_x(60, Selector::DEFAULT);
         card1.style_transform_pivot_y(40, Selector::DEFAULT);
 
@@ -57,15 +77,7 @@ impl View for Style21 {
         let card2 = Obj::new(container)?;
         card2.size(120, 80);
         card2.align(Align::TopRight, -20, 20);
-        card2.bg_color(0xffffff).bg_opa(255);
-        card2.radius(12, Selector::DEFAULT);
-        card2.border_width(0);
-        card2.style_shadow_width(20, Selector::DEFAULT);
-        card2.style_shadow_color(color_make(0x88, 0x88, 0x88), Selector::DEFAULT);
-        card2.style_shadow_offset_x(2, Selector::DEFAULT);
-        card2.style_shadow_offset_y(4, Selector::DEFAULT);
-        card2.style_shadow_spread(0, Selector::DEFAULT);
-        card2.style_shadow_opa(200, Selector::DEFAULT);
+        card2.add_style(&card_style, Selector::DEFAULT);
         card2.style_transform_pivot_x(60, Selector::DEFAULT);
         card2.style_transform_pivot_y(40, Selector::DEFAULT);
 
@@ -76,16 +88,13 @@ impl View for Style21 {
         let controls = Obj::new(container)?;
         controls.size(280, 100);
         controls.align(Align::BottomMid, 0, -10);
-        controls.bg_opa(0);
-        controls.border_width(0);
+        controls.add_style(&controls_style, Selector::DEFAULT);
         controls.set_flex_flow(FlexFlow::Column);
-        controls.pad(4);
-        controls.style_pad_row(8, Selector::DEFAULT);
 
         // Arc — controls rotation
         let arc_row = Obj::new(&controls)?;
         arc_row.size(260, 40);
-        arc_row.bg_opa(0).border_width(0);
+        arc_row.add_style(&row_style, Selector::DEFAULT);
         arc_row.set_flex_flow(FlexFlow::Row);
 
         let arc_lbl = Label::new(&arc_row)?;
@@ -102,7 +111,7 @@ impl View for Style21 {
         // Slider — controls scale
         let slider_row = Obj::new(&controls)?;
         slider_row.size(260, 40);
-        slider_row.bg_opa(0).border_width(0);
+        slider_row.add_style(&row_style, Selector::DEFAULT);
         slider_row.set_flex_flow(FlexFlow::Row);
 
         let slider_lbl = Label::new(&slider_row)?;

--- a/examples/toast_hil_demo.rs
+++ b/examples/toast_hil_demo.rs
@@ -29,6 +29,7 @@
 //! (The rapid-toast sequencing fix is covered by host integration tests.)
 
 use oxivgl::{
+    style::{Selector, Style},
     view::{NavAction, View},
     widgets::{Align, Label, Obj, WidgetError},
 };
@@ -49,8 +50,11 @@ impl ToastView {
 
 impl View for ToastView {
     fn create(&mut self, container: &Obj<'static>) -> Result<(), WidgetError> {
-        container.bg_color(self.bg).bg_opa(255);
-        container.text_color(0x000000);
+        let bg = self.bg;
+        let card_style = Style::new(|s| {
+            s.bg_color_hex(bg).bg_opa(255).text_color_hex(0x000000);
+        });
+        container.add_style(&card_style, Selector::DEFAULT);
         let label = Label::new(container)?;
         label.text(self.text).align(Align::Center, 0, 0);
         self.label = Some(label);
@@ -71,8 +75,10 @@ impl View for ToastDemo {
     fn create(&mut self, container: &Obj<'static>) -> Result<(), WidgetError> {
         // Solid bright green — a color no other app on the rig uses, so the
         // board running this example is unmistakable in the camera frame.
-        container.bg_color(0x18a018).bg_opa(255);
-        container.text_color(0xffffff);
+        let root_style = Style::new(|s| {
+            s.bg_color_hex(0x18a018).bg_opa(255).text_color_hex(0xffffff);
+        });
+        container.add_style(&root_style, Selector::DEFAULT);
         let label = Label::new(container)?;
         label.text("TOAST TEST").align(Align::Center, 0, 0);
         self.label = Some(label);

--- a/examples/widget_arc2.rs
+++ b/examples/widget_arc2.rs
@@ -11,6 +11,7 @@
 
 use oxivgl::{
     anim::{anim_set_arc_value, Anim, ANIM_REPEAT_INFINITE},
+    style::Style,
     view::{NavAction, View},
     enums::{ObjFlag, Opa},
     widgets::{Obj, Arc, Part, WidgetError},
@@ -29,9 +30,10 @@ impl View for WidgetArc2 {
         arc.set_bg_angles(0, 360);
         arc.set_range_raw(0, 100);
         // Hide knob
-        arc.radius(0, Part::Knob);
-        arc.style_opa(Opa::TRANSP.0, Part::Knob);
-        arc.style_pad_all(0, Part::Knob);
+        let knob_style = Style::new(|s| {
+            s.radius(0).opa(Opa::TRANSP.0).pad_all(0);
+        });
+        arc.add_style(&knob_style, Part::Knob);
         // Not interactive
         arc.remove_flag(ObjFlag::CLICKABLE);
         arc.center();

--- a/examples/widget_arc3.rs
+++ b/examples/widget_arc3.rs
@@ -18,7 +18,7 @@ use oxivgl::{
     enums::{EventCode, ObjFlag},
     event::Event,
     math::{trigo_cos, trigo_sin, TRIGO_SHIFT},
-    style::{palette_main, Palette},
+    style::{palette_main, Palette, Selector, Style},
     view::{register_event_on, View},
     widgets::{Align, Arc, ArcMode, Label, Obj, Part, WidgetError},
 };
@@ -83,10 +83,19 @@ impl View for WidgetArc3 {
         let cont = Obj::new(container)?;
         let cont_size = CHART_SIZE + 2 * SLICE_OFFSET;
         cont.size(cont_size, cont_size).center();
-        cont.pad(0);
-        cont.border_width(0);
-        cont.bg_opa(0);
+        let cont_style = Style::new(|s| {
+            s.pad_all(0).border_width(0).bg_opa(0);
+        });
+        cont.add_style(&cont_style, Selector::DEFAULT);
         cont.remove_flag(ObjFlag::SCROLLABLE);
+
+        // Shared arc-width styles, applied to every slice (identical values).
+        let arc_main_style = Style::new(|s| {
+            s.arc_width(CHART_SIZE / 2);
+        });
+        let arc_indicator_style = Style::new(|s| {
+            s.arc_width(0);
+        });
 
         let mut angle_accum: f32 = 0.0;
         let mut arcs_vec = Vec::with_capacity(NUM_SLICES);
@@ -110,10 +119,13 @@ impl View for WidgetArc3 {
             arc.set_bg_end_angle(end);
 
             // Main part = filled pie, indicator = invisible
-            arc.style_arc_width(CHART_SIZE / 2, Part::Main);
-            arc.style_arc_width(0, Part::Indicator);
-            arc.style_arc_color(palette_main(COLORS[i]), Part::Main);
-            arc.style_arc_rounded(false, Part::Main);
+            arc.add_style(&arc_main_style, Part::Main);
+            arc.add_style(&arc_indicator_style, Part::Indicator);
+            // Per-slice color (differs per arc, so not shareable across slices).
+            let arc_color_style = Style::new(|s| {
+                s.arc_color(palette_main(COLORS[i])).arc_rounded(false);
+            });
+            arc.add_style(&arc_color_style, Part::Main);
             arc.remove_style(None, Part::Knob);
             arc.add_flag(ObjFlag::ADV_HITTEST);
             arc.bubble_events();

--- a/examples/widget_arclabel1.rs
+++ b/examples/widget_arclabel1.rs
@@ -9,7 +9,7 @@
 //! Three ArcLabel widgets with different radius, angle, and direction settings.
 
 use oxivgl::{
-    style::Selector,
+    style::{Selector, Style},
     view::{NavAction, View},
     widgets::{Obj, Align, ArcLabel, ArcLabelDir, WidgetError},
 };
@@ -23,9 +23,15 @@ struct WidgetArclabel1 {
 
 impl View for WidgetArclabel1 {
     fn create(&mut self, container: &Obj<'static>) -> Result<(), WidgetError> {
-        container.bg_color(0xffffff).bg_opa(255);
+        let bg_style = Style::new(|s| {
+            s.bg_color_hex(0xffffff).bg_opa(255);
+        });
+        container.add_style(&bg_style, Selector::DEFAULT);
 
         // Large clockwise arc across the top
+        let al1_style = Style::new(|s| {
+            s.text_color_hex(0x2196F3);
+        });
         let al1 = ArcLabel::new(container)?;
         al1.set_text_static(c"Hello curved world!");
         al1.set_radius(90);
@@ -34,9 +40,12 @@ impl View for WidgetArclabel1 {
         al1.set_dir(ArcLabelDir::Clockwise);
         al1.size(200, 200);
         al1.align(Align::Center, 0, -30);
-        al1.text_color(0x2196F3);
+        al1.add_style(&al1_style, Selector::DEFAULT);
 
         // Counter-clockwise arc below
+        let al2_style = Style::new(|s| {
+            s.text_color_hex(0xE91E63);
+        });
         let al2 = ArcLabel::new(container)?;
         al2.set_text_static(c"ArcLabel CCW");
         al2.set_radius(70);
@@ -45,9 +54,12 @@ impl View for WidgetArclabel1 {
         al2.set_dir(ArcLabelDir::CounterClockwise);
         al2.size(160, 160);
         al2.align(Align::Center, -50, 30);
-        al2.text_color(0xE91E63);
+        al2.add_style(&al2_style, Selector::DEFAULT);
 
         // Small clockwise arc, right side
+        let al3_style = Style::new(|s| {
+            s.text_color_hex(0x4CAF50).text_letter_space(4);
+        });
         let al3 = ArcLabel::new(container)?;
         al3.set_text_static(c"OXIVGL");
         al3.set_radius(45);
@@ -56,8 +68,7 @@ impl View for WidgetArclabel1 {
         al3.set_dir(ArcLabelDir::Clockwise);
         al3.size(110, 110);
         al3.align(Align::Center, 70, 40);
-        al3.text_color(0x4CAF50);
-        al3.style_text_letter_space(4, Selector::DEFAULT);
+        al3.add_style(&al3_style, Selector::DEFAULT);
 
                 self._al1 = Some(al1);
         self._al2 = Some(al2);

--- a/examples/widget_bar5.rs
+++ b/examples/widget_bar5.rs
@@ -9,7 +9,7 @@
 //! Two bars side by side: one left-to-right (default), one right-to-left.
 
 use oxivgl::{
-    style::Selector,
+    style::{Selector, Style},
     view::{NavAction, View},
     widgets::{Obj, Align, Bar, BaseDir, Label, WidgetError},
 };
@@ -20,6 +20,7 @@ struct WidgetBar5 {
     _bar_rtl: Option<Bar<'static>>,
     _label_ltr: Option<Label<'static>>,
     _label_rtl: Option<Label<'static>>,
+    _style_rtl: Option<Style>,
 }
 
 impl View for WidgetBar5 {
@@ -41,7 +42,10 @@ impl View for WidgetBar5 {
         bar_rtl.size(200, 20);
         bar_rtl.set_range_raw(0, 100);
         bar_rtl.set_value_raw(70, false);
-        bar_rtl.style_base_dir(BaseDir::Rtl, Selector::DEFAULT);
+        let style_rtl = Style::new(|s| {
+            s.base_dir(BaseDir::Rtl);
+        });
+        bar_rtl.add_style(&style_rtl, Selector::DEFAULT);
         bar_rtl.align(Align::Center, 0, 30);
 
         let label_rtl = Label::new(container)?;
@@ -52,6 +56,7 @@ impl View for WidgetBar5 {
         self._bar_rtl = Some(bar_rtl);
         self._label_ltr = Some(label_ltr);
         self._label_rtl = Some(label_rtl);
+        self._style_rtl = Some(style_rtl);
         Ok(())
     }
 

--- a/examples/widget_buttonmatrix3.rs
+++ b/examples/widget_buttonmatrix3.rs
@@ -40,7 +40,11 @@ impl View for WidgetButtonmatrix3 {
         style_bg
             .pad_all(0)
             .radius(RADIUS_MAX as i16)
-            .border_width(0);
+            .border_width(0)
+            // Clip corners to respect the pill shape
+            .clip_corner(true)
+            // Zero gap between buttons
+            .pad_column(0);
         let style_bg = style_bg.build();
 
         let mut style_btn = StyleBuilder::new();
@@ -56,10 +60,6 @@ impl View for WidgetButtonmatrix3 {
         btnm.set_map(MAP);
         btnm.add_style(&style_bg, Selector::DEFAULT);
         btnm.add_style(&style_btn, Selector::from(Part::Items));
-        // Clip corners to respect the pill shape
-        btnm.style_clip_corner(true, Selector::DEFAULT);
-        // Zero gap between buttons
-        btnm.style_pad_column(0, Selector::DEFAULT);
         btnm.size(225, 35);
         btnm.align(Align::Center, 0, 0);
 

--- a/examples/widget_chart1.rs
+++ b/examples/widget_chart1.rs
@@ -11,7 +11,7 @@
 //! Shadow style on data-point items.
 
 use oxivgl::{
-    style::Selector,
+    style::{Selector, Style},
     view::{NavAction, View},
     widgets::{Obj, Chart, ChartAxis, ChartType, Part, WidgetError},
 };
@@ -34,9 +34,10 @@ impl View for WidgetChart1 {
         chart.set_axis_range(ChartAxis::SecondaryY, 0, 100);
 
         // Shadow on data points
-        chart.style_shadow_width(8, Selector::from(Part::Items));
-        chart.style_shadow_opa(255, Selector::from(Part::Items));
-        chart.style_shadow_offset_x(0, Selector::from(Part::Items));
+        let items_shadow = Style::new(|s| {
+            s.shadow_width(8).shadow_opa(255).shadow_offset_x(0);
+        });
+        chart.add_style(&items_shadow, Selector::from(Part::Items));
 
         // Green series on primary Y
         let color_green = oxivgl::style::palette_main(oxivgl::style::Palette::Green);

--- a/examples/widget_chart3.rs
+++ b/examples/widget_chart3.rs
@@ -10,7 +10,7 @@
 //! each. Simplified from the LVGL C example (no tooltip click events).
 
 use oxivgl::{
-    style::Selector,
+    style::{Selector, Style},
     view::{NavAction, View},
     widgets::{Obj, Chart, ChartAxis, ChartType, WidgetError},
 };
@@ -18,6 +18,7 @@ use oxivgl::{
 #[derive(Default)]
 struct WidgetChart3 {
     _chart: Option<Chart<'static>>,
+    _style: Option<Style>,
 }
 
 impl View for WidgetChart3 {
@@ -29,7 +30,10 @@ impl View for WidgetChart3 {
         chart.set_type(ChartType::Stacked);
         chart.set_point_count(10);
         chart.set_axis_range(ChartAxis::PrimaryY, 0, 100);
-        chart.style_pad_column(4, Selector::DEFAULT);
+        let style = Style::new(|s| {
+            s.pad_column(4);
+        });
+        chart.add_style(&style, Selector::DEFAULT);
 
         let color_red = oxivgl::style::palette_main(oxivgl::style::Palette::Red);
         let ser1 = chart.add_series(color_red, ChartAxis::PrimaryY);
@@ -50,6 +54,7 @@ impl View for WidgetChart3 {
         }
 
         self._chart = Some(chart);
+        self._style = Some(style);
         Ok(())
     }
 

--- a/examples/widget_chart4.rs
+++ b/examples/widget_chart4.rs
@@ -14,7 +14,7 @@ use oxivgl::view::NavAction;
 use oxivgl::{
     enums::EventCode,
     event::Event,
-    style::{color_make, color_mix, palette_main, Palette, Selector},
+    style::{color_make, color_mix, palette_main, Palette, Selector, Style},
     view::{register_event_on, View},
     widgets::{Obj, Chart, ChartAxis, ChartSeries, ChartType, Part, WidgetError},
 };
@@ -33,6 +33,7 @@ struct WidgetChart4 {
     chart: Option<Chart<'static>>,
     _ser: Option<ChartSeries>,
     values: [i32; NUM_POINTS],
+    _style: Option<Style>,
 }
 
 impl View for WidgetChart4 {
@@ -41,7 +42,10 @@ impl View for WidgetChart4 {
         let chart = Chart::new(container)?;
         chart.set_type(ChartType::Bar);
         chart.set_point_count(NUM_POINTS as u32);
-        chart.style_pad_column(2, Selector::DEFAULT);
+        let style = Style::new(|s| {
+            s.pad_column(2);
+        });
+        chart.add_style(&style, Selector::DEFAULT);
         chart.size(260, 160);
         chart.center();
 
@@ -60,6 +64,7 @@ impl View for WidgetChart4 {
         self.chart = Some(chart);
         self._ser = Some(ser);
         self.values = values;
+        self._style = Some(style);
         Ok(())
     }
 

--- a/examples/widget_chart7.rs
+++ b/examples/widget_chart7.rs
@@ -10,7 +10,7 @@
 //! 100 ms. Simplified from LVGL original (no custom draw coloring).
 
 use oxivgl::{
-    style::Selector,
+    style::{Selector, Style},
     timer::Timer,
     view::{NavAction, View},
     widgets::{Obj, Chart, ChartAxis, ChartSeries, ChartType, Part, WidgetError},
@@ -29,6 +29,8 @@ struct WidgetChart7 {
     ser: Option<ChartSeries>,
     timer: Option<Timer>,
     seed: u32,
+    _style_items: Option<Style>,
+    _style_indicator: Option<Style>,
 }
 
 impl View for WidgetChart7 {
@@ -42,8 +44,14 @@ impl View for WidgetChart7 {
         chart.set_axis_range(ChartAxis::PrimaryX, 0, 200);
         chart.set_axis_range(ChartAxis::PrimaryY, 0, 1000);
         // Hide connecting lines — show points only
-        chart.style_line_width(0, Selector::from(Part::Items));
-        chart.style_size(4, 4, Selector::from(Part::Indicator));
+        let style_items = Style::new(|s| {
+            s.line_width(0);
+        });
+        chart.add_style(&style_items, Selector::from(Part::Items));
+        let style_indicator = Style::new(|s| {
+            s.size(4, 4);
+        });
+        chart.add_style(&style_indicator, Selector::from(Part::Indicator));
 
         let color = oxivgl::style::palette_main(oxivgl::style::Palette::Red);
         let ser = chart.add_series(color, ChartAxis::PrimaryY);
@@ -61,6 +69,8 @@ impl View for WidgetChart7 {
         self.ser = Some(ser);
         self.timer = Some(timer);
         self.seed = seed;
+        self._style_items = Some(style_items);
+        self._style_indicator = Some(style_indicator);
         Ok(())
     }
 

--- a/examples/widget_chart8.rs
+++ b/examples/widget_chart8.rs
@@ -11,7 +11,7 @@
 //! the write cursor are blanked to create a visible gap.
 
 use oxivgl::{
-    style::Selector,
+    style::{Selector, Style},
     timer::Timer,
     view::{NavAction, View},
     widgets::{Obj, Chart, ChartAxis, ChartSeries, ChartType, ChartUpdateMode, Part, WidgetError, CHART_POINT_NONE},
@@ -41,7 +41,10 @@ impl View for WidgetChart8 {
         chart.set_type(ChartType::Line);
         chart.set_update_mode(ChartUpdateMode::Circular);
         chart.set_point_count(80);
-        chart.style_size(0, 0, Selector::from(Part::Indicator));
+        let indicator_style = Style::new(|s| {
+            s.size(0, 0);
+        });
+        chart.add_style(&indicator_style, Selector::from(Part::Indicator));
 
         let color = oxivgl::style::palette_main(oxivgl::style::Palette::Red);
         let ser = chart.add_series(color, ChartAxis::PrimaryY);

--- a/examples/widget_image2.rs
+++ b/examples/widget_image2.rs
@@ -9,7 +9,7 @@
 //! Cogwheel image with RGB + intensity sliders controlling recolor tint.
 
 use oxivgl::{
-    style::{color_make, palette_main, Palette, Selector},
+    style::{color_make, palette_main, Palette, Selector, Style},
     view::{NavAction, View},
     widgets::{Obj, Align, Image, Part, Slider, WidgetError},
 };
@@ -44,14 +44,24 @@ impl View for WidgetImage2 {
                 Ok(s)
             };
 
+        let knob_r = Style::new(|s| {
+            s.bg_color(palette_main(Palette::Red));
+        });
+        let knob_g = Style::new(|s| {
+            s.bg_color(palette_main(Palette::Green));
+        });
+        let knob_b = Style::new(|s| {
+            s.bg_color(palette_main(Palette::Blue));
+        });
+
         let slider_r = make_slider(container, 20, 51)?;
-        slider_r.style_bg_color(palette_main(Palette::Red), Part::Knob);
+        slider_r.add_style(&knob_r, Part::Knob);
 
         let slider_g = make_slider(container, 50, 230)?;
-        slider_g.style_bg_color(palette_main(Palette::Green), Part::Knob);
+        slider_g.add_style(&knob_g, Part::Knob);
 
         let slider_b = make_slider(container, 80, 153)?;
-        slider_b.style_bg_color(palette_main(Palette::Blue), Part::Knob);
+        slider_b.add_style(&knob_b, Part::Knob);
 
         let slider_i = make_slider(container, 110, 128)?;
 
@@ -73,6 +83,8 @@ impl View for WidgetImage2 {
             let intense = si.get_value() as u8;
 
             let color = color_make(r, g, b);
+            // runtime-varying style; must stay inline
+            #[allow(deprecated)]
             img.style_image_recolor(color, Selector::DEFAULT)
                 .style_image_recolor_opa(intense, Selector::DEFAULT);
         }

--- a/examples/widget_label1.rs
+++ b/examples/widget_label1.rs
@@ -9,6 +9,7 @@
 //! Two labels: one with word-wrap (centered), one with circular scrolling.
 
 use oxivgl::{
+    style::{Selector, Style},
     view::{NavAction, View},
     widgets::{Obj, Align, Label, LabelLongMode, TextAlign, WidgetError},
 };
@@ -29,7 +30,10 @@ impl View for WidgetLabel1 {
              and wrap long text automatically.",
         );
         label1.width(150);
-        label1.text_align(TextAlign::Center);
+        let label1_style = Style::new(|s| {
+            s.text_align(TextAlign::Center);
+        });
+        label1.add_style(&label1_style, Selector::DEFAULT);
         label1.align(Align::Center, 0, -40);
 
         let label2 = Label::new(container)?;

--- a/examples/widget_label3.rs
+++ b/examples/widget_label3.rs
@@ -12,7 +12,7 @@
 use oxivgl::{
     fonts,
     view::{NavAction, View},
-    style::Selector,
+    style::{Selector, Style},
     widgets::{Obj, Align, BaseDir, Label, WidgetError},
 };
 
@@ -32,7 +32,10 @@ impl View for WidgetLabel3 {
             "In modern terminology, a microcontroller is similar to a \
              system on a chip (SoC).",
         );
-        ltr_label.font(fonts::MONTSERRAT_16);
+        let ltr_style = Style::new(|s| {
+            s.text_font(fonts::MONTSERRAT_16);
+        });
+        ltr_label.add_style(&ltr_style, Selector::DEFAULT);
         ltr_label.width(310);
         ltr_label.align(Align::TopLeft, 5, 5);
 
@@ -46,8 +49,11 @@ impl View for WidgetLabel3 {
              (\u{05D1}\u{05D0}\u{05E0}\u{05D2}\u{05DC}\u{05D9}\u{05EA}: \
              CPU - Central Processing Unit).",
         );
-        rtl_label.style_base_dir(BaseDir::Rtl, Selector::DEFAULT);
-        rtl_label.font(fonts::DEJAVU_16_PERSIAN_HEBREW);
+        let rtl_style = Style::new(|s| {
+            s.text_font(fonts::DEJAVU_16_PERSIAN_HEBREW)
+                .base_dir(BaseDir::Rtl);
+        });
+        rtl_label.add_style(&rtl_style, Selector::DEFAULT);
         rtl_label.width(310);
         rtl_label.align(Align::LeftMid, 5, 0);
 
@@ -60,7 +66,10 @@ impl View for WidgetLabel3 {
              \u{80FD}\u{548C}\u{5B9E}\u{65F6}\u{8BA1}\u{7B97}\u{6027}\u{80FD}\u{7684}\u{8BA1}\
              \u{7B97}\u{673A}\u{7CFB}\u{7EDF}\u{3002}",
         );
-        cjk_label.font(fonts::SOURCE_HAN_SANS_SC_16_CJK);
+        let cjk_style = Style::new(|s| {
+            s.text_font(fonts::SOURCE_HAN_SANS_SC_16_CJK);
+        });
+        cjk_label.add_style(&cjk_style, Selector::DEFAULT);
         cjk_label.width(310);
         cjk_label.align(Align::BottomLeft, 5, -5);
 

--- a/examples/widget_label4.rs
+++ b/examples/widget_label4.rs
@@ -19,7 +19,7 @@ use oxivgl::{
     draw::{Area, DrawLabelDscOwned},
     draw_buf::{ColorFormat, DrawBuf},
     fonts,
-    style::{GradDir, Selector, color_black, color_make, color_white},
+    style::{GradDir, Selector, Style, color_black, color_make, color_white},
     view::{NavAction, View},
     widgets::{Canvas, Obj, TextAlign, WidgetError},
 };
@@ -83,10 +83,13 @@ impl View for WidgetLabel4 {
         let grad = Obj::new(container)?;
         grad.size(MASK_WIDTH as i32, MASK_HEIGHT as i32);
         grad.center();
-        grad.border_width(0);
-        grad.style_bg_color(color_make(0xff, 0, 0), Selector::DEFAULT)
-            .style_bg_grad_color(color_make(0, 0, 0xff), Selector::DEFAULT)
-            .style_bg_grad_dir(GradDir::Hor, Selector::DEFAULT);
+        let grad_style = Style::new(|s| {
+            s.border_width(0)
+                .bg_color(color_make(0xff, 0, 0))
+                .bg_grad_color(color_make(0, 0, 0xff))
+                .bg_grad_dir(GradDir::Hor);
+        });
+        grad.add_style(&grad_style, Selector::DEFAULT);
         // SAFETY: mask is stored in Self._mask (Box) and outlives the grad widget.
         unsafe { grad.style_bitmap_mask_src(&mask, Selector::DEFAULT) };
 

--- a/examples/widget_label6.rs
+++ b/examples/widget_label6.rs
@@ -12,6 +12,7 @@
 
 use oxivgl::{
     fonts::{FixedWidthFont, MONTSERRAT_20},
+    style::{Selector, Style},
     view::{NavAction, View},
     widgets::{Obj, Label, WidgetError},
 };
@@ -30,15 +31,21 @@ impl View for WidgetLabel6 {
     fn create(&mut self, container: &Obj<'static>) -> Result<(), WidgetError> {
 
         // Label with normal proportional font
+        let style_prop = Style::new(|s| {
+            s.text_font(MONTSERRAT_20);
+        });
         let label1 = Label::new(container)?;
-        label1.text_font(MONTSERRAT_20);
+        label1.add_style(&style_prop, Selector::DEFAULT);
         label1.text("0123.Wabc");
 
         // Label with fixed-width glyph override
         let mono = MONO_FONT.init(MONTSERRAT_20, 20);
+        let style_mono = Style::new(|s| {
+            s.text_font(mono);
+        });
         let label2 = Label::new(container)?;
         label2.y(30);
-        label2.text_font(mono);
+        label2.add_style(&style_mono, Selector::DEFAULT);
         label2.text("0123.Wabc");
 
                 self._label1 = Some(label1);

--- a/examples/widget_list2.rs
+++ b/examples/widget_list2.rs
@@ -15,7 +15,7 @@ use oxivgl::{
     enums::{EventCode, ObjFlag, ObjState},
     event::Event,
     layout::FlexFlow,
-    style::lv_pct,
+    style::{lv_pct, Selector, Style},
     symbols,
     view::{register_event_on, View},
     widgets::{Align, AsLvHandle, Button, Child, List, Obj, WidgetError},
@@ -41,7 +41,10 @@ impl View for WidgetList2 {
         // Left list: items
         let list1 = List::new(container)?;
         list1.size(lv_pct(60), lv_pct(100));
-        list1.style_pad_row(5, oxivgl::style::Selector::DEFAULT);
+        let list1_style = Style::new(|s| {
+            s.pad_row(5);
+        });
+        list1.add_style(&list1_style, Selector::DEFAULT);
 
         let mut item_btns = heapless::Vec::<Button<'static>, 15>::new();
         for i in 0..15 {

--- a/examples/widget_menu4.rs
+++ b/examples/widget_menu4.rs
@@ -12,7 +12,7 @@
 use oxivgl::{
     enums::{EventCode, ObjFlag},
     event::Event,
-    style::Selector,
+    style::{Selector, Style},
     symbols,
     view::{NavAction, View},
     widgets::{Obj, Align, Button, Label, Menu, WidgetError, RADIUS_MAX},
@@ -55,7 +55,10 @@ impl View for WidgetMenu4 {
         float_btn.add_flag(ObjFlag::FLOATING);
         float_btn.align(Align::BottomRight, -10, -10);
         float_btn.bubble_events();
-        float_btn.radius(RADIUS_MAX, Selector::DEFAULT);
+        let float_btn_style = Style::new(|s| {
+            s.radius(RADIUS_MAX as i16);
+        });
+        float_btn.add_style(&float_btn_style, Selector::DEFAULT);
         float_btn.style_bg_image_src_symbol(&symbols::PLUS, Selector::DEFAULT);
 
                 self.menu = Some(menu);

--- a/examples/widget_menu5.rs
+++ b/examples/widget_menu5.rs
@@ -17,7 +17,7 @@
 use oxivgl::{
     enums::{EventCode, ObjFlag, ObjState},
     event::Event,
-    style::{color_brightness, color_darken, Selector},
+    style::{color_brightness, color_darken, Selector, Style},
     symbols,
     view::{NavAction, View},
     widgets::{
@@ -116,19 +116,25 @@ impl View for WidgetMenu5 {
         } else {
             color_darken(bg, 50)
         };
-        menu.style_bg_color(darkened, Selector::DEFAULT);
+        let menu_bg_style = Style::new(|s| {
+            s.bg_color(darkened);
+        });
+        menu.add_style(&menu_bg_style, Selector::DEFAULT);
 
         menu.set_mode_root_back_button(true);
         menu.bubble_events();
         menu.size(320, 240).center();
 
         let header_pad = menu.get_main_header().get_style_pad_left(Part::Main);
+        let header_pad_style = Style::new(|s| {
+            s.pad_hor(header_pad);
+        });
 
         // ── Sub-pages ──────────────────────────────────────────────────
 
         // Mechanics
         let sub_mechanics = menu.page_create(None);
-        sub_mechanics.style_pad_hor(header_pad, Selector::DEFAULT);
+        sub_mechanics.add_style(&header_pad_style, Selector::DEFAULT);
         Menu::separator_create(&sub_mechanics);
         let section = Menu::section_create(&sub_mechanics);
         create_slider(&section, &symbols::SETTINGS, "Velocity", 0, 150, 120);
@@ -137,27 +143,27 @@ impl View for WidgetMenu5 {
 
         // Sound
         let sub_sound = menu.page_create(None);
-        sub_sound.style_pad_hor(header_pad, Selector::DEFAULT);
+        sub_sound.add_style(&header_pad_style, Selector::DEFAULT);
         Menu::separator_create(&sub_sound);
         let section = Menu::section_create(&sub_sound);
         create_switch(&section, &symbols::AUDIO, "Sound", false);
 
         // Display
         let sub_display = menu.page_create(None);
-        sub_display.style_pad_hor(header_pad, Selector::DEFAULT);
+        sub_display.add_style(&header_pad_style, Selector::DEFAULT);
         Menu::separator_create(&sub_display);
         let section = Menu::section_create(&sub_display);
         create_slider(&section, &symbols::SETTINGS, "Brightness", 0, 150, 100);
 
         // Software info
         let sub_sw_info = menu.page_create(None);
-        sub_sw_info.style_pad_hor(header_pad, Selector::DEFAULT);
+        sub_sw_info.add_style(&header_pad_style, Selector::DEFAULT);
         let section = Menu::section_create(&sub_sw_info);
         create_text(&section, None, "Version 1.0", false);
 
         // Legal info
         let sub_legal = menu.page_create(None);
-        sub_legal.style_pad_hor(header_pad, Selector::DEFAULT);
+        sub_legal.add_style(&header_pad_style, Selector::DEFAULT);
         let section = Menu::section_create(&sub_legal);
         for _ in 0..15 {
             create_text(
@@ -170,7 +176,7 @@ impl View for WidgetMenu5 {
 
         // About
         let sub_about = menu.page_create(None);
-        sub_about.style_pad_hor(header_pad, Selector::DEFAULT);
+        sub_about.add_style(&header_pad_style, Selector::DEFAULT);
         Menu::separator_create(&sub_about);
         let section = Menu::section_create(&sub_about);
         let cont = create_text(&section, None, "Software information", false);
@@ -180,7 +186,7 @@ impl View for WidgetMenu5 {
 
         // Menu mode
         let sub_menu_mode = menu.page_create(None);
-        sub_menu_mode.style_pad_hor(header_pad, Selector::DEFAULT);
+        sub_menu_mode.add_style(&header_pad_style, Selector::DEFAULT);
         Menu::separator_create(&sub_menu_mode);
         let section = Menu::section_create(&sub_menu_mode);
         create_switch(&section, &symbols::AUDIO, "Sidebar enable", true);
@@ -188,7 +194,7 @@ impl View for WidgetMenu5 {
         // ── Root page (sidebar) ────────────────────────────────────────
 
         let root_page = menu.page_create(Some("Settings"));
-        root_page.style_pad_hor(header_pad, Selector::DEFAULT);
+        root_page.add_style(&header_pad_style, Selector::DEFAULT);
 
         let section = Menu::section_create(&root_page);
         let cont = create_text(&section, Some(&symbols::SETTINGS), "Mechanics", false);

--- a/examples/widget_msgbox2.rs
+++ b/examples/widget_msgbox2.rs
@@ -12,7 +12,7 @@
 
 use oxivgl::{
     layout::FlexFlow,
-    style::Selector,
+    style::{Selector, Style},
     view::{NavAction, View},
     widgets::{Obj, Child, Label, Msgbox, Slider, WidgetError},
 };
@@ -33,7 +33,10 @@ impl View for WidgetMsgbox2 {
         let mbox = Msgbox::new(Some(container))?;
         mbox.size(300, 200);
         mbox.center();
-        mbox.style_clip_corner(true, Selector::DEFAULT);
+        let mbox_style = Style::new(|s| {
+            s.clip_corner(true);
+        });
+        mbox.add_style(&mbox_style, Selector::DEFAULT);
 
         // Title + header buttons
         mbox.add_title("Settings");
@@ -43,7 +46,10 @@ impl View for WidgetMsgbox2 {
         // Content area — flex column with sliders
         let content = mbox.get_content();
         content.set_flex_flow(FlexFlow::Column);
-        content.pad(10);
+        let content_style = Style::new(|s| {
+            s.pad_all(10);
+        });
+        content.add_style(&content_style, Selector::DEFAULT);
 
         let lbl_bright = Label::new(&*content)?;
         lbl_bright.text("Brightness");
@@ -73,8 +79,10 @@ impl View for WidgetMsgbox2 {
         // Style footer with indigo background
         let footer = mbox.get_footer().expect("footer exists after add_footer_button");
         let indigo = oxivgl::style::palette_main(oxivgl::style::Palette::Indigo);
-        footer.style_bg_color(indigo, Selector::DEFAULT);
-        footer.bg_opa(255);
+        let footer_style = Style::new(|s| {
+            s.bg_color(indigo).bg_opa(255);
+        });
+        footer.add_style(&footer_style, Selector::DEFAULT);
 
         self._mbox = Some(mbox);
         self._lbl_bright = Some(lbl_bright);

--- a/examples/widget_msgbox3.rs
+++ b/examples/widget_msgbox3.rs
@@ -15,7 +15,7 @@
 //! is always visible.
 
 use oxivgl::{
-    style::Selector,
+    style::{Selector, Style},
     view::{NavAction, View},
     widgets::{Align, Label, Msgbox, Obj, Screen, WidgetError},
 };
@@ -45,8 +45,10 @@ impl View for WidgetMsgbox3 {
 
         // Style layer_top for blur + dimming (applied to the msgbox backdrop)
         let layer = Screen::layer_top();
-        layer.style_blur_radius(20, Selector::DEFAULT);
-        layer.style_blur_backdrop(true, Selector::DEFAULT);
+        let blur_style = Style::new(|s| {
+            s.blur_radius(20).blur_backdrop(true);
+        });
+        layer.add_style(&blur_style, Selector::DEFAULT);
         // Prevent layer_top from being deleted on drop — LVGL owns it
         core::mem::forget(layer);
 

--- a/examples/widget_roller2.rs
+++ b/examples/widget_roller2.rs
@@ -45,7 +45,8 @@ impl View for WidgetRoller2 {
         sb_green
             .bg_color_hex(0x00FF00)
             .bg_grad_color_hex(0xAAFFAA)
-            .bg_grad_dir(GradDir::Ver);
+            .bg_grad_dir(GradDir::Ver)
+            .text_align(TextAlign::Left);
         let style_green = sb_green.build();
 
         // Left roller: left-aligned text, green gradient, 2 visible rows
@@ -55,7 +56,6 @@ impl View for WidgetRoller2 {
         r1.width(100);
         r1.add_style(&style_sel, Selector::from(Part::Selected));
         r1.add_style(&style_green, Selector::DEFAULT);
-        r1.text_align(TextAlign::Left);
         r1.align(Align::LeftMid, 10, 0);
         r1.set_selected(2, false);
 
@@ -73,7 +73,10 @@ impl View for WidgetRoller2 {
         r3.set_visible_row_count(4);
         r3.width(80);
         r3.add_style(&style_sel, Selector::from(Part::Selected));
-        r3.text_align(TextAlign::Right);
+        let style_align_right = Style::new(|s| {
+            s.text_align(TextAlign::Right);
+        });
+        r3.add_style(&style_align_right, Selector::DEFAULT);
         r3.align(Align::RightMid, -10, 0);
         r3.set_selected(8, false);
 

--- a/examples/widget_roller3.rs
+++ b/examples/widget_roller3.rs
@@ -59,7 +59,10 @@ struct WidgetRoller3 {
 
 impl View for WidgetRoller3 {
     fn create(&mut self, container: &Obj<'static>) -> Result<(), WidgetError> {
-        container.bg_color(0x607D8B); // LV_PALETTE_BLUE_GREY
+        let mut cont_sb = StyleBuilder::new();
+        cont_sb.bg_color_hex(0x607D8B); // LV_PALETTE_BLUE_GREY
+        let cont_style = cont_sb.build();
+        container.add_style(&cont_style, Selector::DEFAULT);
 
         let mut sb = StyleBuilder::new();
         sb.bg_color(color_black())
@@ -68,9 +71,14 @@ impl View for WidgetRoller3 {
             .radius(0);
         let style = sb.build();
 
+        // Selected-row background opacity (shared style for Part::Selected).
+        let mut sel_sb = StyleBuilder::new();
+        sel_sb.bg_opa(50);
+        let sel_style = sel_sb.build();
+
         let roller = Roller::new(container)?;
         roller.add_style(&style, Selector::DEFAULT);
-        roller.bg_opa_selector(50, Part::Selected);
+        roller.add_style(&sel_style, Part::Selected);
         roller.set_options(
             "January\n\
              February\n\

--- a/examples/widget_scale11.rs
+++ b/examples/widget_scale11.rs
@@ -37,6 +37,12 @@ static HOUR_LABELS: &ScaleLabels = scale_labels!(
 struct WidgetScale11 {
     _bg: Option<Obj<'static>>,
     scale: Option<Scale<'static>>,
+    _bg_style: Option<Style>,
+    _scale_default_style: Option<Style>,
+    _scale_indicator_style: Option<Style>,
+    _today_style: Option<Style>,
+    _caption_style: Option<Style>,
+    _time_style: Option<Style>,
     _tick_style: Option<Style>,
     _night_style: Option<Style>,
     _day_style: Option<Style>,
@@ -70,17 +76,23 @@ impl View for WidgetScale11 {
         // Dark circular background
         let bg = Obj::new(container)?;
         bg.size(210, 210).center();
-        bg.radius(i32::MAX, Selector::DEFAULT);
-        bg.style_bg_color(palette_darken(Palette::Grey, 4), Selector::DEFAULT);
-        bg.bg_opa(255);
+        let bg_style = Style::new(|s| {
+            s.bg_color(palette_darken(Palette::Grey, 4))
+                .bg_opa(255)
+                .pad_all(0)
+                .radius_circle();
+        });
+        bg.add_style(&bg_style, Selector::DEFAULT);
         bg.remove_scrollable();
-        bg.pad(0);
 
         // Scale
         let scale = Scale::new(&bg)?;
         scale.center();
         scale.size(150, 150);
-        scale.style_arc_width(5, Selector::DEFAULT);
+        let scale_default_style = Style::new(|s| {
+            s.arc_width(5);
+        });
+        scale.add_style(&scale_default_style, Selector::DEFAULT);
 
         scale.set_mode(ScaleMode::RoundOuter);
         scale.set_range(0, 24);
@@ -89,8 +101,10 @@ impl View for WidgetScale11 {
         scale.set_angle_range(360);
         scale.set_rotation(105);
         scale.set_label_show(true);
-        scale.style_text_font(fonts::MONTSERRAT_12, Part::Indicator);
-        scale.style_radial_offset(-6, Part::Indicator);
+        let scale_indicator_style = Style::new(|s| {
+            s.text_font(fonts::MONTSERRAT_12).radial_offset(-6);
+        });
+        scale.add_style(&scale_indicator_style, Part::Indicator);
 
         // Rotate labels to match tick angles, keep upright
         scale.style_transform_rotation(
@@ -128,41 +142,56 @@ impl View for WidgetScale11 {
         // Enable draw task events for label recoloring
         scale.send_draw_task_events();
 
+        // Shared label styles (built once, applied to multiple labels).
+        let today_style = Style::new(|s| {
+            s.text_font(fonts::MONTSERRAT_16).text_color(color_white());
+        });
+        // SUNRISE/SUNSET captions: 14pt grey.
+        let caption_style = Style::new(|s| {
+            s.text_font(fonts::MONTSERRAT_14)
+                .text_color(palette_main(Palette::Grey));
+        });
+        // Time values: 20pt white.
+        let time_style = Style::new(|s| {
+            s.text_font(fonts::MONTSERRAT_20).text_color(color_white());
+        });
+
         // "TODAY" label
         let today = Label::new(&bg)?;
         today.text("TODAY");
-        today.style_text_font(fonts::MONTSERRAT_16, Selector::DEFAULT);
-        today.style_text_color(color_white(), Selector::DEFAULT);
+        today.add_style(&today_style, Selector::DEFAULT);
         today.align(Align::TopMid, 0, 60);
 
         // Sunrise
         let sunrise_lbl = Label::new(&bg)?;
         sunrise_lbl.text("SUNRISE");
-        sunrise_lbl.style_text_font(fonts::MONTSERRAT_14, Selector::DEFAULT);
-        sunrise_lbl.style_text_color(palette_main(Palette::Grey), Selector::DEFAULT);
+        sunrise_lbl.add_style(&caption_style, Selector::DEFAULT);
         sunrise_lbl.align(Align::LeftMid, 37, -10);
 
         let sunrise_time = Label::new(&bg)?;
         sunrise_time.text("6:43");
-        sunrise_time.style_text_font(fonts::MONTSERRAT_20, Selector::DEFAULT);
-        sunrise_time.style_text_color(color_white(), Selector::DEFAULT);
+        sunrise_time.add_style(&time_style, Selector::DEFAULT);
         sunrise_time.align_to(&sunrise_lbl, Align::OutBottomMid, 0, 2);
 
         // Sunset
         let sunset_lbl = Label::new(&bg)?;
         sunset_lbl.text("SUNSET");
-        sunset_lbl.style_text_font(fonts::MONTSERRAT_14, Selector::DEFAULT);
-        sunset_lbl.style_text_color(palette_main(Palette::Grey), Selector::DEFAULT);
+        sunset_lbl.add_style(&caption_style, Selector::DEFAULT);
         sunset_lbl.align(Align::RightMid, -37, -10);
 
         let sunset_time = Label::new(&bg)?;
         sunset_time.text("17:37");
-        sunset_time.style_text_font(fonts::MONTSERRAT_20, Selector::DEFAULT);
-        sunset_time.style_text_color(color_white(), Selector::DEFAULT);
+        sunset_time.add_style(&time_style, Selector::DEFAULT);
         sunset_time.align_to(&sunset_lbl, Align::OutBottomMid, 0, 2);
 
                 self._bg = Some(bg);
         self.scale = Some(scale);
+        self._bg_style = Some(bg_style);
+        self._scale_default_style = Some(scale_default_style);
+        self._scale_indicator_style = Some(scale_indicator_style);
+        self._today_style = Some(today_style);
+        self._caption_style = Some(caption_style);
+        self._time_style = Some(time_style);
         self._tick_style = Some(tick_style);
         self._night_style = Some(night_style);
         self._day_style = Some(day_style);

--- a/examples/widget_scale12.rs
+++ b/examples/widget_scale12.rs
@@ -14,7 +14,7 @@ use oxivgl::{
     fonts,
     scale_labels,
     style::{
-        Palette, Selector, StyleBuilder, color_white, palette_darken, palette_main,
+        Palette, Selector, Style, StyleBuilder, color_white, palette_darken, palette_main,
     },
     view::{NavAction, View},
     widgets::{
@@ -34,6 +34,10 @@ struct WidgetScale12 {
     _needle: Option<Line<'static>>,
     _needle_style: Option<oxivgl::style::Style>,
     _tick_style: Option<oxivgl::style::Style>,
+    _bg_style: Option<oxivgl::style::Style>,
+    _scale_arc_style: Option<oxivgl::style::Style>,
+    _scale_text_style: Option<oxivgl::style::Style>,
+    _heading_style: Option<oxivgl::style::Style>,
     _heading_lbl: Option<Label<'static>>,
 }
 
@@ -43,17 +47,23 @@ impl View for WidgetScale12 {
         // Dark circular background
         let bg = Obj::new(container)?;
         bg.size(220, 220).center();
-        bg.radius(i32::MAX, Selector::DEFAULT);
-        bg.style_bg_color(palette_darken(Palette::Grey, 4), Selector::DEFAULT);
-        bg.bg_opa(255);
+        let bg_style = Style::new(|s| {
+            s.bg_color(palette_darken(Palette::Grey, 4))
+                .bg_opa(255)
+                .pad_all(0)
+                .radius_circle();
+        });
+        bg.add_style(&bg_style, Selector::DEFAULT);
         bg.remove_scrollable();
-        bg.pad(0);
 
         // Scale — round inner, 8 compass points
         let scale = Scale::new(&bg)?;
         scale.center();
         scale.size(200, 200);
-        scale.style_arc_width(3, Selector::DEFAULT);
+        let scale_arc_style = Style::new(|s| {
+            s.arc_width(3);
+        });
+        scale.add_style(&scale_arc_style, Selector::DEFAULT);
 
         scale.set_mode(ScaleMode::RoundInner);
         scale.set_range(0, 360);
@@ -62,8 +72,9 @@ impl View for WidgetScale12 {
         scale.set_angle_range(360);
         scale.set_rotation(270); // N at top (initial)
         scale.set_label_show(true);
-        scale.style_text_font(fonts::MONTSERRAT_14, Part::Indicator);
-        scale.style_text_color(color_white(), Part::Indicator);
+        let scale_text_style = Style::new(|s| {
+            s.text_font(fonts::MONTSERRAT_14).text_color(color_white());
+        });
 
         // Rotate labels to match tick angles, keep upright
         scale.style_transform_rotation(
@@ -79,6 +90,7 @@ impl View for WidgetScale12 {
             .width(12);
         let tick_style = tick_sb.build();
         scale.add_style(&tick_style, Part::Indicator);
+        scale.add_style(&scale_text_style, Part::Indicator);
 
         // Custom compass labels
         scale.set_text_src(COMPASS_LABELS);
@@ -94,8 +106,10 @@ impl View for WidgetScale12 {
         // "HEADING" label
         let heading_lbl = Label::new(&bg)?;
         heading_lbl.text("COMPASS");
-        heading_lbl.style_text_font(fonts::MONTSERRAT_16, Selector::DEFAULT);
-        heading_lbl.style_text_color(color_white(), Selector::DEFAULT);
+        let heading_style = Style::new(|s| {
+            s.text_font(fonts::MONTSERRAT_16).text_color(color_white());
+        });
+        heading_lbl.add_style(&heading_style, Selector::DEFAULT);
         heading_lbl.align(Align::Center, 0, 30);
 
         // Animation: rotate scale 0 -> 3600 (ten full circles) over 10s, infinite repeat
@@ -113,6 +127,10 @@ impl View for WidgetScale12 {
         self._needle = Some(needle);
         self._needle_style = Some(needle_style);
         self._tick_style = Some(tick_style);
+        self._bg_style = Some(bg_style);
+        self._scale_arc_style = Some(scale_arc_style);
+        self._scale_text_style = Some(scale_text_style);
+        self._heading_style = Some(heading_style);
         self._heading_lbl = Some(heading_lbl);
         Ok(())
     }

--- a/examples/widget_scale6.rs
+++ b/examples/widget_scale6.rs
@@ -47,10 +47,9 @@ impl View for WidgetScale6 {
 
         // Dark background with clipped corners
         let mut sb = StyleBuilder::new();
-        sb.bg_opa(153).bg_color(color_black()).radius(RADIUS_MAX as i16);
+        sb.bg_opa(153).bg_color(color_black()).radius(RADIUS_MAX as i16).clip_corner(true);
         let bg_style = sb.build();
         scale.add_style(&bg_style, Selector::DEFAULT);
-        scale.style_clip_corner(true, Selector::DEFAULT);
 
         // Indicator style: yellow labels + major tick lines
         let mut sb = StyleBuilder::new();

--- a/examples/widget_scale7.rs
+++ b/examples/widget_scale7.rs
@@ -15,7 +15,7 @@ use oxivgl::{
     draw::DrawTask,
     enums::EventCode,
     event::Event,
-    style::{lv_pct, palette_main, Palette},
+    style::{lv_pct, palette_main, Palette, Style},
     view::{register_event_on, View},
     widgets::{Obj, Part, Scale, ScaleMode, WidgetError},
 };
@@ -85,8 +85,14 @@ impl View for WidgetScale7 {
         scale.set_total_tick_count(31);
         scale.set_major_tick_every(5);
 
-        scale.style_length(5, Part::Items);
-        scale.style_length(10, Part::Indicator);
+        let minor_len = Style::new(|s| {
+            s.length(5);
+        });
+        let major_len = Style::new(|s| {
+            s.length(10);
+        });
+        scale.add_style(&minor_len, Part::Items);
+        scale.add_style(&major_len, Part::Indicator);
         scale.set_range(10, 40);
 
         scale.send_draw_task_events();

--- a/examples/widget_scale8.rs
+++ b/examples/widget_scale8.rs
@@ -30,10 +30,13 @@ impl View for WidgetScale8 {
         scale.set_mode(ScaleMode::RoundInner);
 
         // Red-tinted background, fully round
-        scale
+        let mut bg_sb = StyleBuilder::new();
+        bg_sb
             .bg_opa(255)
-            .style_bg_color(palette_lighten(Palette::Red, 5), Selector::DEFAULT)
-            .radius(RADIUS_MAX, Selector::DEFAULT);
+            .bg_color(palette_lighten(Palette::Red, 5))
+            .radius(RADIUS_MAX as i16);
+        let bg_style = bg_sb.build();
+        scale.add_style(&bg_style, Selector::DEFAULT);
 
         scale.align(Align::LeftMid, lv_pct(2), 0);
 
@@ -44,12 +47,17 @@ impl View for WidgetScale8 {
         );
         scale.style_translate_x(10, Part::Indicator);
         scale.set_tick_length(Part::Indicator, 15);
-        scale.style_radial_offset(10, Part::Indicator);
+        let mut indicator_sb = StyleBuilder::new();
+        indicator_sb.radial_offset(10);
+        let indicator_style = indicator_sb.build();
+        scale.add_style(&indicator_style, Part::Indicator);
 
         // Minor ticks
         scale.set_tick_length(Part::Items, 10);
-        scale.style_radial_offset(5, Part::Items);
-        scale.style_line_opa(128, Part::Items);
+        let mut items_sb = StyleBuilder::new();
+        items_sb.radial_offset(5).line_opa(128);
+        let items_style = items_sb.build();
+        scale.add_style(&items_style, Part::Items);
 
         scale
             .set_label_show(true)

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -91,7 +91,8 @@ pub static SOURCE_HAN_SANS_SC_16_CJK: Font =
 ///
 /// // In View::create():
 /// let font = MONO_FONT.init(MONTSERRAT_20, 20);
-/// label.text_font(font);
+/// let style = oxivgl::style::Style::new(|s| { s.text_font(font); });
+/// label.add_style(&style, oxivgl::style::Selector::DEFAULT);
 /// ```
 pub struct FixedWidthFont {
     inner: UnsafeCell<MaybeUninit<lv_font_t>>,

--- a/src/style/style.rs
+++ b/src/style/style.rs
@@ -213,6 +213,88 @@ impl StyleBuilder {
         self
     }
 
+    /// Set corner radius to a full circle/pill (`LV_RADIUS_CIRCLE`).
+    pub fn radius_circle(&mut self) -> &mut Self {
+        // 0x7FFF == LV_RADIUS_CIRCLE; LVGL clamps to half the object size.
+        unsafe { lv_style_set_radius(&mut self.inner.lv, 0x7FFF as lv_coord_t) };
+        self
+    }
+
+    /// Set horizontal padding (left and right).
+    pub fn pad_hor(&mut self, p: i32) -> &mut Self {
+        unsafe { lv_style_set_pad_hor(&mut self.inner.lv, p) };
+        self
+    }
+
+    /// Set the gap between columns (flex/grid).
+    pub fn pad_column(&mut self, gap: i32) -> &mut Self {
+        unsafe { lv_style_set_pad_column(&mut self.inner.lv, gap) };
+        self
+    }
+
+    /// Set the gap between rows (flex/grid).
+    pub fn pad_row(&mut self, gap: i32) -> &mut Self {
+        unsafe { lv_style_set_pad_row(&mut self.inner.lv, gap) };
+        self
+    }
+
+    /// Set width and height together.
+    pub fn size(&mut self, w: i32, h: i32) -> &mut Self {
+        unsafe {
+            lv_style_set_width(&mut self.inner.lv, w);
+            lv_style_set_height(&mut self.inner.lv, h);
+        }
+        self
+    }
+
+    /// Clip child content to the (rounded) corners.
+    pub fn clip_corner(&mut self, clip: bool) -> &mut Self {
+        unsafe { lv_style_set_clip_corner(&mut self.inner.lv, clip) };
+        self
+    }
+
+    /// Set horizontal text alignment.
+    pub fn text_align(&mut self, align: crate::widgets::TextAlign) -> &mut Self {
+        unsafe { lv_style_set_text_align(&mut self.inner.lv, align as lv_text_align_t) };
+        self
+    }
+
+    /// Set the base text direction (LTR/RTL/auto).
+    pub fn base_dir(&mut self, dir: crate::widgets::BaseDir) -> &mut Self {
+        unsafe { lv_style_set_base_dir(&mut self.inner.lv, dir as lv_base_dir_t) };
+        self
+    }
+
+    /// Set the radial offset (scale/arc tick placement).
+    pub fn radial_offset(&mut self, offset: i32) -> &mut Self {
+        unsafe { lv_style_set_radial_offset(&mut self.inner.lv, offset) };
+        self
+    }
+
+    /// Set line opacity (0 = transparent, 255 = opaque).
+    pub fn line_opa(&mut self, opa: u8) -> &mut Self {
+        unsafe { lv_style_set_line_opa(&mut self.inner.lv, opa as lv_opa_t) };
+        self
+    }
+
+    /// Round the ends of arcs drawn with this style.
+    pub fn arc_rounded(&mut self, rounded: bool) -> &mut Self {
+        unsafe { lv_style_set_arc_rounded(&mut self.inner.lv, rounded) };
+        self
+    }
+
+    /// Set backdrop blur radius.
+    pub fn blur_radius(&mut self, r: i32) -> &mut Self {
+        unsafe { lv_style_set_blur_radius(&mut self.inner.lv, r) };
+        self
+    }
+
+    /// Enable backdrop blur (blur what is behind the object).
+    pub fn blur_backdrop(&mut self, en: bool) -> &mut Self {
+        unsafe { lv_style_set_blur_backdrop(&mut self.inner.lv, en) };
+        self
+    }
+
     /// Set overall object opacity (0-255).
     pub fn opa(&mut self, opa: u8) -> &mut Self {
         unsafe { lv_style_set_opa(&mut self.inner.lv, opa as lv_opa_t) };
@@ -392,6 +474,12 @@ impl StyleBuilder {
     /// Set top padding.
     pub fn pad_top(&mut self, p: i32) -> &mut Self {
         unsafe { lv_style_set_pad_top(&mut self.inner.lv, p) };
+        self
+    }
+
+    /// Set bottom padding.
+    pub fn pad_bottom(&mut self, p: i32) -> &mut Self {
+        unsafe { lv_style_set_pad_bottom(&mut self.inner.lv, p) };
         self
     }
 

--- a/src/widgets/calendar.rs
+++ b/src/widgets/calendar.rs
@@ -189,7 +189,10 @@ impl<'p> Calendar<'p> {
             // triggers a render pass. The btnmatrix must already have
             // the CJK font when rendering occurs.
             let bm = self.get_btnmatrix();
+            // Internal widget setup: apply the CJK font directly to the btnmatrix.
+            #[allow(deprecated)]
             bm.font(cjk_font);
+            #[allow(deprecated)]
             bm.style_text_font(cjk_font, crate::widgets::obj::Part::Items);
         }
         unsafe { lv_calendar_set_chinese_mode(self.obj.handle(), en) };

--- a/src/widgets/obj_style.rs
+++ b/src/widgets/obj_style.rs
@@ -13,6 +13,7 @@ use super::obj::Obj;
 // selector variants take lv_color_t for full control.
 impl<'p> Obj<'p> {
     /// Set background color from RGB hex (selector 0).
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn bg_color(&self, color: u32) -> &Self {
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
         // SAFETY: handle non-null (asserted above).
@@ -21,6 +22,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set background opacity (selector 0).
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn bg_opa(&self, opa: u8) -> &Self {
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
         // SAFETY: handle non-null (asserted above).
@@ -29,6 +31,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set background opacity for the given selector.
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn bg_opa_selector(&self, opa: u8, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -38,6 +41,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set border width (selector 0).
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn border_width(&self, w: i32) -> &Self {
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
         // SAFETY: handle non-null (asserted above).
@@ -46,6 +50,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set padding on all sides (selector 0).
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn pad(&self, p: i32) -> &Self {
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
         // SAFETY: handle non-null (asserted above).
@@ -54,6 +59,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set top padding (selector 0).
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn pad_top(&self, p: i32) -> &Self {
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
         // SAFETY: handle non-null (asserted above).
@@ -62,6 +68,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set bottom padding (selector 0).
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn pad_bottom(&self, p: i32) -> &Self {
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
         // SAFETY: handle non-null (asserted above).
@@ -70,6 +77,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set left padding (selector 0).
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn pad_left(&self, p: i32) -> &Self {
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
         // SAFETY: handle non-null (asserted above).
@@ -78,6 +86,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set right padding (selector 0).
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn pad_right(&self, p: i32) -> &Self {
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
         // SAFETY: handle non-null (asserted above).
@@ -86,6 +95,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set horizontal padding (left + right) for the given selector.
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_pad_hor(&self, p: i32, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -158,6 +168,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set `clip_corner` — clip overflowing content at rounded corners.
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_clip_corner(&self, clip: bool, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -176,6 +187,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set text color from RGB hex (selector 0).
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn text_color(&self, color: u32) -> &Self {
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
         // SAFETY: handle non-null (asserted above).
@@ -184,6 +196,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set text font (selector 0).
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn text_font(&self, font: crate::fonts::Font) -> &Self {
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
         assert_ne!(font.as_ptr(), null_mut(), "Font pointer cannot be null");
@@ -193,11 +206,14 @@ impl<'p> Obj<'p> {
     }
 
     /// Alias for [`text_font`](Self::text_font).
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
+    #[allow(deprecated)] // alias forwards to the (also deprecated) text_font
     pub fn font(&self, font: crate::fonts::Font) -> &Self {
         self.text_font(font)
     }
 
     /// Set text alignment (selector 0).
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn text_align(&self, align: super::obj::TextAlign) -> &Self {
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
         // SAFETY: handle non-null (asserted above).
@@ -206,6 +222,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set overall opacity (selector 0).
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn opa(&self, opa: u8) -> &Self {
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
         // SAFETY: handle non-null (asserted above).
@@ -214,6 +231,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set opacity for the given style selector.
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_opa(&self, opa: u8, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -223,6 +241,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set padding on all sides for the given style selector.
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_pad_all(&self, p: i32, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -233,6 +252,7 @@ impl<'p> Obj<'p> {
 
     /// Set the corner radius for the given style selector.
     /// Use [`RADIUS_MAX`](super::RADIUS_MAX) for a pill/capsule shape.
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn radius(&self, r: i32, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -242,6 +262,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set local `bg_color` style for the given selector (part | state).
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_bg_color(&self, color: lv_color_t, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -251,6 +272,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set local `bg_grad_color` for the given selector.
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_bg_grad_color(&self, color: lv_color_t, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -260,6 +282,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set local `bg_grad_dir` for the given selector.
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_bg_grad_dir(&self, dir: crate::style::GradDir, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -308,6 +331,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set base text direction for the given selector.
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_base_dir(&self, dir: super::obj::BaseDir, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -317,6 +341,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set `lv_obj_set_style_line_width` for the given LVGL style part.
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn line_width(&self, part: super::obj::Part, width: i32) -> &Self {
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
         // SAFETY: handle non-null (asserted above).
@@ -325,6 +350,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set image recolor tint.
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_image_recolor(&self, color: lv_color_t, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -334,6 +360,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set radial offset for parts on round scales (in pixels).
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_radial_offset(&self, offset: i32, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -343,6 +370,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set line opacity for a part (0–255).
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_line_opa(&self, opa: u8, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -352,6 +380,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set text color for the given style selector.
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_text_color(&self, color: lv_color_t, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -361,6 +390,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set text font for the given style selector.
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_text_font(&self, font: crate::fonts::Font, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -371,6 +401,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set arc width for the given style selector.
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_arc_width(&self, width: i32, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -380,6 +411,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set arc color for the given style selector.
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_arc_color(&self, color: lv_color_t, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -389,6 +421,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set arc rounded end-caps for the given style selector.
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_arc_rounded(&self, rounded: bool, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -398,6 +431,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set line color for the given style selector.
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_line_color(&self, color: lv_color_t, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -409,6 +443,7 @@ impl<'p> Obj<'p> {
     /// Set the `length` property for the given style selector.
     ///
     /// Used for tick length on scale parts (Items=minor, Indicator=major).
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_length(&self, length: i32, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -418,6 +453,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set line width for the given style selector.
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_line_width(&self, width: i32, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -430,6 +466,7 @@ impl<'p> Obj<'p> {
     ///
     /// Different from [`Obj::size`] — this sets the style property, useful
     /// for sub-parts like tick marks.
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_width(&self, width: i32, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -439,6 +476,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set image recolor opacity (0–255).
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_image_recolor_opa(&self, opa: u8, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -448,6 +486,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set column gap for the given selector.
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_pad_column(&self, gap: i32, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -457,6 +496,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set row gap for the given selector.
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_pad_row(&self, gap: i32, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -466,6 +506,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set indicator/point width and height for the given selector.
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_size(&self, w: i32, h: i32, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -546,6 +587,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set shadow width for the given selector.
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_shadow_width(&self, w: i32, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -555,6 +597,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set shadow color for the given selector.
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_shadow_color(&self, color: lv_color_t, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -564,6 +607,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set shadow X offset for the given selector.
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_shadow_offset_x(&self, x: i32, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -573,6 +617,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set shadow Y offset for the given selector.
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_shadow_offset_y(&self, y: i32, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -582,6 +627,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set shadow spread for the given selector.
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_shadow_spread(&self, s: i32, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -591,6 +637,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set shadow opacity (0–255) for the given selector.
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_shadow_opa(&self, opa: u8, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -618,6 +665,7 @@ impl<'p> Obj<'p> {
     }
 
     /// Set text letter spacing for the given selector.
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_text_letter_space(&self, space: i32, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -630,6 +678,7 @@ impl<'p> Obj<'p> {
     ///
     /// Requires GPU-accelerated backend for visible effect; may be a no-op on
     /// SDL host.
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_blur_radius(&self, r: i32, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");
@@ -642,6 +691,7 @@ impl<'p> Obj<'p> {
     ///
     /// When enabled, the area behind the object is blurred (requires
     /// [`style_blur_radius`](Self::style_blur_radius) > 0).
+    #[deprecated(note = "inline style setters allocate a per-object local style; build a shared Style (Style::new) and apply with add_style for memory efficiency at scale - see docs/memory-tuning.md")]
     pub fn style_blur_backdrop(&self, en: bool, selector: impl Into<crate::style::Selector>) -> &Self {
         let selector = selector.into().raw();
         assert_ne!(self.handle(), null_mut(), "Obj handle cannot be null");

--- a/src/widgets/screen.rs
+++ b/src/widgets/screen.rs
@@ -29,9 +29,14 @@ use crate::{
 ///
 /// ```no_run
 /// use oxivgl::widgets::Screen;
+/// use oxivgl::style::{Selector, Style};
 ///
 /// let screen = Screen::active().expect("LVGL not initialized");
-/// screen.bg_color(0x06080f).bg_opa(255).pad_top(6).pad_bottom(6);
+/// // Build the screen's look once as a shared style and apply it.
+/// let bg = Style::new(|s| {
+///     s.bg_color_hex(0x06080f).bg_opa(255).pad_top(6).pad_bottom(6);
+/// });
+/// screen.add_style(&bg, Selector::DEFAULT);
 /// ```
 pub struct Screen {
     handle: *mut lv_obj_t,

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -4,6 +4,9 @@
 //! Run with: `SDL_VIDEODRIVER=dummy cargo +nightly test --test integration
 //!   --target x86_64-unknown-linux-gnu -- --test-threads=1`
 
+// Tests exercise the deprecated inline style setters to verify they still work.
+#![allow(deprecated)]
+
 #[path = "../common/mod.rs"]
 mod common;
 

--- a/tests/integration/style.rs
+++ b/tests/integration/style.rs
@@ -105,6 +105,34 @@ fn obj_bg_image_src_and_recolor_direct() {
     pump();
 }
 
+// ── New StyleBuilder methods (shared-style equivalents of inline setters) ─────
+
+#[test]
+fn style_builder_new_methods_apply() {
+    use oxivgl::widgets::{BaseDir, TextAlign};
+    let screen = fresh_screen();
+    let style = Style::new(|s| {
+        s.pad_hor(4)
+            .pad_bottom(2)
+            .pad_column(6)
+            .pad_row(8)
+            .size(40, 20)
+            .clip_corner(true)
+            .text_align(TextAlign::Center)
+            .base_dir(BaseDir::Rtl)
+            .radial_offset(3)
+            .line_opa(128)
+            .arc_rounded(true)
+            .blur_radius(2)
+            .blur_backdrop(false)
+            .radius_circle();
+    });
+    let obj = Obj::new(&screen).unwrap();
+    obj.add_style(&style, Selector::DEFAULT);
+    obj.size(80, 40);
+    pump();
+}
+
 // ── Style::new + build-and-forget ────────────────────────────────────────────
 
 #[test]

--- a/tests/leak_check.rs
+++ b/tests/leak_check.rs
@@ -11,6 +11,9 @@
 //! Run with: `SDL_VIDEODRIVER=dummy cargo +nightly test --test leak_check
 //!   --target x86_64-unknown-linux-gnu -- --test-threads=1`
 
+// Tests exercise the deprecated inline style setters to verify they still work.
+#![allow(deprecated)]
+
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::sync::atomic::{AtomicIsize, Ordering};
 


### PR DESCRIPTION
## Summary

Steers styling to the memory-efficient **shared-`Style`** model and migrates the entire example suite. **Stacked on #103** (which is on #102).

Per-object inline `style_*` setters each allocate a local style — a `styles[]` entry **plus its own property buffer**. A shared `Style` amortizes to **one** buffer for every widget that uses it, cutting heap *and* style-refresh compute wherever a treatment repeats (a pure win; no per-frame cost).

## What's in it
- **Deprecate 49 shareable inline setters** on `Obj` (`#[deprecated]`). Transforms and image-content setters are **excluded** — they're inherently per-instance/dynamic.
- **Fill `StyleBuilder` gaps** so every deprecated setter has a shared-style path (you can't validly deprecate without an alternative): adds `pad_hor`, `pad_column`, `pad_row`, `size`, `clip_corner`, `text_align`, `base_dir`, `radial_offset`, `line_opa`, `arc_rounded`, `blur_radius`, `blur_backdrop`, `radius_circle`.
- **Migrate all 56 example files** off inline setters to `Style::new` + `add_style`.
- **Dynamic styling stays inline.** A few sites mutate style *per-frame* (animated opacity in `scroll6`/`scroll7`, live RGB recolor in `widget_image2`) — these can't be a shared static style, so they keep the inline setter with a localized `#[allow(deprecated)]` + comment. **This is the one nuance:** blanket deprecation does flag legitimate dynamic styling, which needs explicit allow.
- **Internal/test opt-outs:** the calendar CJK-font internal setup and the test crates (which must exercise the deprecated-but-functional API) use `#[allow(deprecated)]`.

## Regression testing (screenshots, as requested)
Regenerated all screenshots and pixel-diffed against committed baselines: **53 of 54 migrated examples are byte-identical**. The lone diff (`widget_label1`) is **animation-timing noise** in an *un-migrated* circularly-scrolling label (caught at a different scroll phase) — the migrated `text_align` label is pixel-identical. So the migration is faithful.

## Verification
- **0 deprecated warnings** across lib + examples + tests (forced recompile).
- Tests: **55 unit + 38 doc + 529 integration** pass (incl. a new test exercising all 13 builder methods, and `Style::new` build-and-forget).
- `missing-docs` clean; CI hard-rules clean (no `oxivgl_sys`; the only `unsafe` are the pre-existing CI-exempt `style_bitmap_mask_src` sites).
- Host-only; no target/HIL.

## Scope note
The "~70 affected examples" estimate was grep-inflated (it counted `builder.bg_color(...)` — the target form). The compiler-authoritative count was **54** (+ 2 pilot = 56 total migrated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)