### PR TITLE
fix: remove 127-byte silent truncation from text setters (#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Text setters no longer silently truncate at 127 bytes** (#105). Every
+  `&str`-taking setter — `Textarea::{set_text, add_text, set_placeholder_text}`,
+  `Label::text`, `Checkbox::text`, `List::{add_text, add_button}`,
+  `Msgbox::{add_title, add_text, add_footer_button}`, `Table::set_cell_value`,
+  `Win::add_title`, `Menu::page_create`, `Label::set_translation_tag`, and the
+  `Label::bind_text_map` updater — previously copied through a fixed `[u8; 128]`
+  stack buffer and dropped everything past 127 bytes with no error. They now
+  pass the full string through a heap-backed NUL-terminated temporary (LVGL
+  copies it internally), so text of any length is rendered verbatim. This also
+  removes 15 per-call 128-byte stack temporaries from widget construction.
+
+### Deprecated
+
+- **`Label::text_long`** — `Label::text` is now itself uncapped, so the two are
+  identical. `text_long` remains as an alias and will be removed in a future
+  release; call `text` directly.
+
 ## [0.4.0] — 2026-06-10
 
 ### Added

--- a/examples/scroll4.rs
+++ b/examples/scroll4.rs
@@ -39,7 +39,7 @@ impl View for Scroll4 {
         let label = Label::new(&obj)?;
         // Constrain label width so text wraps and overflows vertically
         label.width(200);
-        label.text_long(concat!(
+        label.text(concat!(
             "Lorem ipsum dolor sit amet, consectetur adipiscing elit.\n",
             "Etiam dictum, tortor vestibulum lacinia laoreet, ",
             "mi neque consectetur neque, vel mattis odio dolor egestas ligula.\n",

--- a/examples/widget_label1.rs
+++ b/examples/widget_label1.rs
@@ -25,7 +25,7 @@ impl View for WidgetLabel1 {
 
         let label1 = Label::new(container)?;
         label1.set_long_mode(LabelLongMode::Wrap);
-        label1.text_long(
+        label1.text(
             "Words of a label, align the lines to the center \
              and wrap long text automatically.",
         );

--- a/examples/widget_label2.rs
+++ b/examples/widget_label2.rs
@@ -34,13 +34,13 @@ impl View for WidgetLabel2 {
         shadow_label.add_style(&style_shadow, Selector::DEFAULT);
 
         let main_label = Label::new(container)?;
-        main_label.text_long(
+        main_label.text(
             "A simple method to create\nshadows on a text.\n\
              It even works with\n\nnewlines     and spaces.",
         );
 
         // Copy shadow text from main label (use same string)
-        shadow_label.text_long(
+        shadow_label.text(
             "A simple method to create\nshadows on a text.\n\
              It even works with\n\nnewlines     and spaces.",
         );

--- a/examples/widget_label3.rs
+++ b/examples/widget_label3.rs
@@ -28,7 +28,7 @@ impl View for WidgetLabel3 {
 
         // LTR English label
         let ltr_label = Label::new(container)?;
-        ltr_label.text_long(
+        ltr_label.text(
             "In modern terminology, a microcontroller is similar to a \
              system on a chip (SoC).",
         );
@@ -41,7 +41,7 @@ impl View for WidgetLabel3 {
 
         // RTL Hebrew label
         let rtl_label = Label::new(container)?;
-        rtl_label.text_long(
+        rtl_label.text(
             "\u{05DE}\u{05E2}\u{05D1}\u{05D3}, \u{05D0}\u{05D5} \
              \u{05D1}\u{05E9}\u{05DE}\u{05D5} \u{05D4}\u{05DE}\u{05DC}\u{05D0} \
              \u{05D9}\u{05D7}\u{05D9}\u{05D3}\u{05EA} \u{05E2}\u{05D9}\u{05D1}\u{05D5}\u{05D3} \
@@ -59,7 +59,7 @@ impl View for WidgetLabel3 {
 
         // Chinese label
         let cjk_label = Label::new(container)?;
-        cjk_label.text_long(
+        cjk_label.text(
             "\u{5D4C}\u{5165}\u{5F0F}\u{7CFB}\u{7EDF}\u{FF08}Embedded System\u{FF09}\u{FF0C}\n\
              \u{662F}\u{4E00}\u{79CD}\u{5D4C}\u{5165}\u{673A}\u{68B0}\u{6216}\u{7535}\u{6C14}\
              \u{7CFB}\u{7EDF}\u{5185}\u{90E8}\u{3001}\u{5177}\u{6709}\u{4E13}\u{4E00}\u{529F}\

--- a/src/widgets/checkbox.rs
+++ b/src/widgets/checkbox.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-use core::{ffi::c_char, ops::Deref, ptr::null_mut};
+use core::{ops::Deref, ptr::null_mut};
 
 use oxivgl_sys::*;
 
 use super::{
-    WidgetError,
+    WidgetError, with_cstr,
     obj::{AsLvHandle, Obj},
 };
 
@@ -53,15 +53,13 @@ impl<'p> Checkbox<'p> {
         cstr.to_str().ok()
     }
 
-    /// Set checkbox label text. Truncates at 127 bytes.
+    /// Set checkbox label text. Accepts any `&str` (no length cap); LVGL copies
+    /// the string internally.
     pub fn text(&self, s: &str) -> &Self {
         assert_ne!(self.obj.handle(), null_mut(), "Checkbox handle cannot be null");
-        let bytes = s.as_bytes();
-        let len = bytes.len().min(127);
-        let mut buf = [0u8; 128];
-        buf[..len].copy_from_slice(&bytes[..len]);
-        // SAFETY: handle non-null (asserted above); buf is NUL-terminated.
-        unsafe { lv_checkbox_set_text(self.obj.handle(), buf.as_ptr() as *const c_char) };
+        // SAFETY: handle non-null (asserted above); with_cstr supplies a
+        // NUL-terminated buffer valid for the call. LVGL copies internally.
+        with_cstr(s, |p| unsafe { lv_checkbox_set_text(self.obj.handle(), p) });
         self
     }
 }

--- a/src/widgets/label.rs
+++ b/src/widgets/label.rs
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-use alloc::vec::Vec;
-use core::{ffi::{c_char, c_void}, ops::Deref, ptr::null_mut};
+use core::{ffi::c_void, ops::Deref, ptr::null_mut};
 
 use oxivgl_sys::*;
 
 use super::{
     obj::{AsLvHandle, Obj},
     subject::Subject,
-    WidgetError,
+    with_cstr, WidgetError,
 };
 
 /// LVGL text label widget.
@@ -56,18 +55,13 @@ impl<'p> Label<'p> {
         }
     }
 
-    /// Set label text. Accepts any `&str` (no NUL terminator required).
-    /// LVGL copies the string internally. Truncates at 127 bytes.
-    /// For longer text use [`text_long`](Self::text_long).
+    /// Set label text. Accepts any `&str` (no length cap, no NUL terminator
+    /// required); LVGL copies the string internally.
     pub fn text(&self, s: &str) -> &Self {
         assert_ne!(self.obj.handle(), null_mut(), "Label handle cannot be null");
-        let bytes = s.as_bytes();
-        let len = bytes.len().min(127);
-        let mut buf = [0u8; 128];
-        buf[..len].copy_from_slice(&bytes[..len]);
-        // SAFETY: handle non-null (asserted above); buf is NUL-terminated
-        // (zero-initialized, len ≤ 127).
-        unsafe { lv_label_set_text(self.obj.handle(), buf.as_ptr() as *const c_char) };
+        // SAFETY: handle non-null (asserted above); with_cstr supplies a
+        // NUL-terminated buffer valid for the call. LVGL copies internally.
+        with_cstr(s, |p| unsafe { lv_label_set_text(self.obj.handle(), p) });
         self
     }
 
@@ -77,28 +71,22 @@ impl<'p> Label<'p> {
     /// Requires `LV_USE_TRANSLATION = 1` in `lv_conf.h`.
     pub fn set_translation_tag(&self, tag: &str) -> &Self {
         assert_ne!(self.obj.handle(), null_mut(), "Label handle cannot be null");
-        let len = tag.len().min(127);
-        let mut buf = [0u8; 128];
-        buf[..len].copy_from_slice(&tag.as_bytes()[..len]);
-        // SAFETY: handle non-null; buf is NUL-terminated (zero-initialized).
-        // LVGL copies the string via lv_strdup (see lv_label_set_translation_tag
-        // in lv_label.c), so passing a stack buffer is safe — no pointer is
-        // retained after this call returns.
-        unsafe { lv_label_set_translation_tag(self.obj.handle(), buf.as_ptr() as *const c_char) };
+        // SAFETY: handle non-null (asserted above); with_cstr supplies a
+        // NUL-terminated buffer valid for the call. LVGL copies the string via
+        // lv_strdup (see lv_label_set_translation_tag in lv_label.c), so no
+        // pointer is retained after this call returns.
+        with_cstr(tag, |p| unsafe { lv_label_set_translation_tag(self.obj.handle(), p) });
         self
     }
 
-    /// Set label text without the 127-byte limit. Heap-allocates a
-    /// NUL-terminated copy. Use [`text`](Self::text) for short UI labels.
+    /// Set label text without a length limit.
+    ///
+    /// Equivalent to [`text`](Self::text), which is now itself uncapped — kept
+    /// as a deprecated alias for callers written against the old 127-byte
+    /// `text`.
+    #[deprecated(note = "`text` is now uncapped; call `text` directly")]
     pub fn text_long(&self, s: &str) -> &Self {
-        assert_ne!(self.obj.handle(), null_mut(), "Label handle cannot be null");
-        let mut buf = Vec::with_capacity(s.len() + 1);
-        buf.extend_from_slice(s.as_bytes());
-        buf.push(0);
-        // SAFETY: handle non-null (asserted above); buf is NUL-terminated.
-        // LVGL copies the string internally so buf can be dropped.
-        unsafe { lv_label_set_text(self.obj.handle(), buf.as_ptr() as *const c_char) };
-        self
+        self.text(s)
     }
 
     /// Set the label long mode (wrap, scroll, clip, etc.).
@@ -174,13 +162,8 @@ impl<'p> Label<'p> {
                 let value = lv_subject_get_int(subject);
                 let text = map(value);
                 let label_ptr = lv_observer_get_target_obj(observer);
-                // Copy &str to NUL-terminated stack buffer for LVGL.
-                let bytes = text.as_bytes();
-                let mut buf = [0u8; 128];
-                let len = bytes.len().min(127);
-                buf[..len].copy_from_slice(&bytes[..len]);
-                // buf[len] is already 0 from zero-init.
-                lv_label_set_text(label_ptr, buf.as_ptr() as *const core::ffi::c_char);
+                // Pass the mapped &str to LVGL as a NUL-terminated string.
+                with_cstr(text, |p| lv_label_set_text(label_ptr, p));
             }
         }
         // SAFETY: lv_handle() non-null; subject pinned; fn pointer is pointer-sized.

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-use core::{ffi::c_char, ops::Deref, ptr::null_mut};
+use core::{ops::Deref, ptr::null_mut};
 
 use oxivgl_sys::*;
 
 use super::{
-    WidgetError,
+    WidgetError, with_cstr,
     button::Button,
     child::Child,
     obj::{AsLvHandle, Obj},
@@ -67,13 +67,10 @@ impl<'p> List<'p> {
     /// list — do not store or drop it separately.
     pub fn add_text(&self, text: &str) -> &Self {
         assert_ne!(self.obj.handle(), null_mut(), "List handle cannot be null");
-        let bytes = text.as_bytes();
-        let len = bytes.len().min(127);
-        let mut buf = [0u8; 128];
-        buf[..len].copy_from_slice(&bytes[..len]);
-        // SAFETY: handle non-null (asserted above); buf is NUL-terminated
-        // (zero-initialized, len <= 127). LVGL copies the text (lv_list.c:81).
-        unsafe { lv_list_add_text(self.obj.handle(), buf.as_ptr() as *const c_char) };
+        // SAFETY: handle non-null (asserted above); with_cstr supplies a
+        // NUL-terminated buffer valid for the call. LVGL copies the text
+        // (lv_list.c:81).
+        with_cstr(text, |p| unsafe { lv_list_add_text(self.obj.handle(), p) });
         self
     }
 
@@ -87,18 +84,17 @@ impl<'p> List<'p> {
     /// owned by the list widget. Use it for event registration or styling.
     pub fn add_button(&self, icon: Option<&Symbol>, text: &str) -> Child<Button<'p>> {
         assert_ne!(self.obj.handle(), null_mut(), "List handle cannot be null");
-        let bytes = text.as_bytes();
-        let len = bytes.len().min(127);
-        let mut buf = [0u8; 128];
-        buf[..len].copy_from_slice(&bytes[..len]);
         let icon_ptr = match icon {
             Some(sym) => sym.as_ptr() as *const core::ffi::c_void,
             None => core::ptr::null(),
         };
         // SAFETY: handle non-null (asserted above); icon_ptr is NULL or a valid
-        // symbol string pointer; buf is NUL-terminated. LVGL creates child
-        // widgets that are owned by the list (lv_list.c:88-106).
-        let btn_ptr = unsafe { lv_list_add_button(self.obj.handle(), icon_ptr, buf.as_ptr() as *const c_char) };
+        // symbol string pointer; with_cstr supplies a NUL-terminated text buffer
+        // valid for the call. LVGL creates child widgets that are owned by the
+        // list (lv_list.c:88-106).
+        let btn_ptr = with_cstr(text, |p| unsafe {
+            lv_list_add_button(self.obj.handle(), icon_ptr, p)
+        });
         assert!(!btn_ptr.is_null(), "lv_list_add_button returned NULL");
         // The button is a child of the list — wrap as Child to suppress Drop.
         Child::new(Button::from_raw(btn_ptr))

--- a/src/widgets/menu.rs
+++ b/src/widgets/menu.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-use core::{ffi::c_char, ops::Deref, ptr::null_mut};
+use core::{ops::Deref, ptr::null_mut};
 
 use oxivgl_sys::*;
 
 use super::{
-    WidgetError,
+    WidgetError, with_cstr,
     child::Child,
     obj::{AsLvHandle, Obj},
 };
@@ -82,23 +82,13 @@ impl<'p> Menu<'p> {
     /// the menu — wrap in [`Child`](super::Child) if you need to keep a handle.
     pub fn page_create(&self, title: Option<&str>) -> Child<Obj<'p>> {
         assert_ne!(self.obj.handle(), null_mut(), "Menu handle cannot be null");
-        // `_buf` must remain live until after `lv_menu_page_create` returns —
-        // `ptr` points into it. Do NOT rename `_buf` to `_` (that would drop
-        // it immediately, making `ptr` a dangling pointer).
-        let (ptr, _buf) = match title {
-            Some(t) => {
-                let bytes = t.as_bytes();
-                let len = bytes.len().min(127);
-                let mut buf = [0u8; 128];
-                buf[..len].copy_from_slice(&bytes[..len]);
-                (buf.as_ptr() as *const c_char, Some(buf))
-            }
-            None => (core::ptr::null(), None),
+        // SAFETY: menu handle non-null (asserted above); the title pointer is
+        // NULL (untitled) or a NUL-terminated buffer valid for the call. LVGL
+        // copies the title (lv_menu.c creates a label child with the text).
+        let page = match title {
+            Some(t) => with_cstr(t, |p| unsafe { lv_menu_page_create(self.obj.handle(), p) }),
+            None => unsafe { lv_menu_page_create(self.obj.handle(), core::ptr::null()) },
         };
-        // SAFETY: menu handle non-null (asserted above); ptr is NULL or points
-        // to a NUL-terminated stack buffer live until end of this block.
-        // LVGL copies the title (lv_menu.c creates a label child with the text).
-        let page = unsafe { lv_menu_page_create(self.obj.handle(), ptr) };
         assert!(!page.is_null(), "lv_menu_page_create returned NULL");
         Child::new(Obj::from_raw(page))
     }

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -1,12 +1,34 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //! Type-safe LVGL widget wrappers and supporting types.
 
+use alloc::vec::Vec;
+use core::ffi::c_char;
+
 use heapless::c_string::ExtendError;
 use thiserror_no_std::Error;
 
 /// Internal LVGL integer scale: physical values are mapped to `0..LVGL_SCALE`
 /// for arc/bar ranges.
 pub(crate) const LVGL_SCALE: i32 = 1000;
+
+/// Build a NUL-terminated copy of `s` on the heap and invoke `f` with a pointer
+/// to it. The pointer is valid only for the duration of `f`.
+///
+/// Every LVGL text setter wrapped by this crate copies the string into the
+/// widget's own storage before returning (`lv_strdup` / label-child creation),
+/// so the temporary buffer may be freed as soon as `f` returns. Unlike a
+/// fixed-size stack buffer, this imposes **no length cap** — text of any size
+/// is passed through verbatim — and keeps the caller's stack frame to a single
+/// pointer, which matters where setters are inlined into the render task.
+///
+/// A `&str` cannot be handed to C directly because it is not NUL-terminated;
+/// this is the one allocation that bridges that gap.
+pub(crate) fn with_cstr<R>(s: &str, f: impl FnOnce(*const c_char) -> R) -> R {
+    let mut buf = Vec::with_capacity(s.len() + 1);
+    buf.extend_from_slice(s.as_bytes());
+    buf.push(0);
+    f(buf.as_ptr() as *const c_char)
+}
 
 /// Map a physical value `v` in `0..max` to LVGL's integer range
 /// `0..LVGL_SCALE`. Returns 0 if `max` is 0 to avoid division by zero.

--- a/src/widgets/msgbox.rs
+++ b/src/widgets/msgbox.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-use core::{ffi::c_char, ops::Deref, ptr::null_mut};
+use core::{ops::Deref, ptr::null_mut};
 
 use oxivgl_sys::*;
 
 use super::{
-    WidgetError,
+    WidgetError, with_cstr,
     child::Child,
     obj::{AsLvHandle, Obj},
 };
@@ -74,13 +74,10 @@ impl<'p> Msgbox<'p> {
     /// LVGL copies the string internally.
     pub fn add_title(&self, title: &str) -> &Self {
         assert_ne!(self.obj.handle(), null_mut(), "Msgbox handle cannot be null");
-        let bytes = title.as_bytes();
-        let len = bytes.len().min(127);
-        let mut buf = [0u8; 128];
-        buf[..len].copy_from_slice(&bytes[..len]);
-        // SAFETY: handle non-null (asserted above); buf is NUL-terminated.
-        // LVGL copies the text (lv_msgbox.c creates a label child).
-        unsafe { lv_msgbox_add_title(self.obj.handle(), buf.as_ptr() as *const c_char) };
+        // SAFETY: handle non-null (asserted above); with_cstr supplies a
+        // NUL-terminated buffer valid for the call. LVGL copies the text
+        // (lv_msgbox.c creates a label child).
+        with_cstr(title, |p| unsafe { lv_msgbox_add_title(self.obj.handle(), p) });
         self
     }
 
@@ -90,13 +87,9 @@ impl<'p> Msgbox<'p> {
     /// labels stacked vertically.
     pub fn add_text(&self, text: &str) -> &Self {
         assert_ne!(self.obj.handle(), null_mut(), "Msgbox handle cannot be null");
-        let bytes = text.as_bytes();
-        let len = bytes.len().min(127);
-        let mut buf = [0u8; 128];
-        buf[..len].copy_from_slice(&bytes[..len]);
-        // SAFETY: handle non-null (asserted above); buf is NUL-terminated.
-        // LVGL copies the text.
-        unsafe { lv_msgbox_add_text(self.obj.handle(), buf.as_ptr() as *const c_char) };
+        // SAFETY: handle non-null (asserted above); with_cstr supplies a
+        // NUL-terminated buffer valid for the call. LVGL copies the text.
+        with_cstr(text, |p| unsafe { lv_msgbox_add_text(self.obj.handle(), p) });
         self
     }
 
@@ -115,12 +108,11 @@ impl<'p> Msgbox<'p> {
     /// LVGL copies the string internally.
     pub fn add_footer_button(&self, text: &str) -> Child<Obj<'_>> {
         assert_ne!(self.obj.handle(), null_mut(), "Msgbox handle cannot be null");
-        let bytes = text.as_bytes();
-        let len = bytes.len().min(127);
-        let mut buf = [0u8; 128];
-        buf[..len].copy_from_slice(&bytes[..len]);
-        // SAFETY: handle non-null; buf is NUL-terminated. LVGL copies the text.
-        let btn = unsafe { lv_msgbox_add_footer_button(self.obj.handle(), buf.as_ptr() as *const c_char) };
+        // SAFETY: handle non-null (asserted above); with_cstr supplies a
+        // NUL-terminated buffer valid for the call. LVGL copies the text.
+        let btn = with_cstr(text, |p| unsafe {
+            lv_msgbox_add_footer_button(self.obj.handle(), p)
+        });
         assert!(!btn.is_null(), "lv_msgbox_add_footer_button returned NULL");
         Child::new(Obj::from_raw(btn))
     }

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 use alloc::string::String;
-use core::{ffi::c_char, ops::Deref, ptr::null_mut};
+use core::{ops::Deref, ptr::null_mut};
 
 use oxivgl_sys::*;
 
 use super::{
-    WidgetError,
+    WidgetError, with_cstr,
     obj::{AsLvHandle, Obj},
 };
 
@@ -99,15 +99,13 @@ impl<'p> Table<'p> {
     /// Set the text of a cell. LVGL copies the string internally.
     ///
     /// New rows/columns are added automatically if `row`/`col` exceed the
-    /// current count. Strings longer than 127 bytes are silently truncated.
+    /// current count. Accepts any `&str` (no length cap); LVGL copies the text.
     pub fn set_cell_value(&self, row: u32, col: u32, text: &str) -> &Self {
-        let bytes = text.as_bytes();
-        let len = bytes.len().min(127);
-        let mut buf = [0u8; 128];
-        buf[..len].copy_from_slice(&bytes[..len]);
-        // SAFETY: handle non-null; buf is NUL-terminated; LVGL copies the text
-        // (lv_table.c: lv_strdup used internally).
-        unsafe { lv_table_set_cell_value(self.lv_handle(), row, col, buf.as_ptr() as *const c_char) };
+        // SAFETY: with_cstr supplies a NUL-terminated buffer valid for the call;
+        // LVGL copies the text (lv_table.c: lv_strdup used internally).
+        with_cstr(text, |p| unsafe {
+            lv_table_set_cell_value(self.lv_handle(), row, col, p)
+        });
         self
     }
 

--- a/src/widgets/textarea.rs
+++ b/src/widgets/textarea.rs
@@ -4,7 +4,7 @@ use core::{ffi::c_char, ops::Deref, ptr::null_mut};
 use oxivgl_sys::*;
 
 use super::{
-    WidgetError,
+    WidgetError, with_cstr,
     obj::{AsLvHandle, Obj},
 };
 
@@ -52,14 +52,13 @@ impl<'p> Textarea<'p> {
         if handle.is_null() { Err(WidgetError::LvglNullPointer) } else { Ok(Textarea { obj: Obj::from_raw(handle) }) }
     }
 
-    /// Set the textarea text. LVGL copies the string internally.
+    /// Set the textarea text. Accepts any `&str` (no length cap); LVGL copies
+    /// the string internally.
     pub fn set_text(&self, text: &str) -> &Self {
         assert_ne!(self.obj.handle(), null_mut(), "Textarea handle cannot be null");
-        let mut buf = [0u8; 128];
-        let len = text.len().min(127);
-        buf[..len].copy_from_slice(&text.as_bytes()[..len]);
-        // SAFETY: handle non-null; buf is NUL-terminated. LVGL copies internally.
-        unsafe { lv_textarea_set_text(self.obj.handle(), buf.as_ptr() as *const c_char) };
+        // SAFETY: handle non-null (asserted above); with_cstr supplies a
+        // NUL-terminated buffer valid for the call. LVGL copies internally.
+        with_cstr(text, |p| unsafe { lv_textarea_set_text(self.obj.handle(), p) });
         self
     }
 
@@ -80,14 +79,13 @@ impl<'p> Textarea<'p> {
         cstr.to_str().ok()
     }
 
-    /// Append text at the cursor position. LVGL copies the string internally.
+    /// Append text at the cursor position. Accepts any `&str` (no length cap);
+    /// LVGL copies the string internally.
     pub fn add_text(&self, text: &str) -> &Self {
         assert_ne!(self.obj.handle(), null_mut(), "Textarea handle cannot be null");
-        let mut buf = [0u8; 128];
-        let len = text.len().min(127);
-        buf[..len].copy_from_slice(&text.as_bytes()[..len]);
-        // SAFETY: handle non-null; buf is NUL-terminated. LVGL copies internally.
-        unsafe { lv_textarea_add_text(self.obj.handle(), buf.as_ptr() as *const c_char) };
+        // SAFETY: handle non-null (asserted above); with_cstr supplies a
+        // NUL-terminated buffer valid for the call. LVGL copies internally.
+        with_cstr(text, |p| unsafe { lv_textarea_add_text(self.obj.handle(), p) });
         self
     }
 
@@ -107,15 +105,13 @@ impl<'p> Textarea<'p> {
         self
     }
 
-    /// Set placeholder text shown when the textarea is empty.
-    /// LVGL copies the string internally.
+    /// Set placeholder text shown when the textarea is empty. Accepts any
+    /// `&str` (no length cap); LVGL copies the string internally.
     pub fn set_placeholder_text(&self, text: &str) -> &Self {
         assert_ne!(self.obj.handle(), null_mut(), "Textarea handle cannot be null");
-        let mut buf = [0u8; 128];
-        let len = text.len().min(127);
-        buf[..len].copy_from_slice(&text.as_bytes()[..len]);
-        // SAFETY: handle non-null; buf is NUL-terminated. LVGL copies internally.
-        unsafe { lv_textarea_set_placeholder_text(self.obj.handle(), buf.as_ptr() as *const c_char) };
+        // SAFETY: handle non-null (asserted above); with_cstr supplies a
+        // NUL-terminated buffer valid for the call. LVGL copies internally.
+        with_cstr(text, |p| unsafe { lv_textarea_set_placeholder_text(self.obj.handle(), p) });
         self
     }
 

--- a/src/widgets/win.rs
+++ b/src/widgets/win.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-use core::{ffi::c_char, ops::Deref, ptr::null_mut};
+use core::{ops::Deref, ptr::null_mut};
 
 use oxivgl_sys::*;
 
 use super::{
-    WidgetError,
+    WidgetError, with_cstr,
     child::Child,
     obj::{AsLvHandle, Obj},
 };
@@ -68,16 +68,12 @@ impl<'p> Win<'p> {
     /// Add a title label to the header. The returned handle is a label widget
     /// owned by the window's header.
     ///
-    /// `txt` is truncated to 127 bytes. LVGL copies the string internally.
+    /// Accepts any `&str` (no length cap). LVGL copies the string internally.
     pub fn add_title(&self, txt: &str) -> Child<Obj<'p>> {
-        let bytes = txt.as_bytes();
-        let len = bytes.len().min(127);
-        let mut buf = [0u8; 128];
-        buf[..len].copy_from_slice(&bytes[..len]);
-        // SAFETY: handle non-null (constructor guarantees); buf is
-        // NUL-terminated; LVGL copies the text into an internal label.
-        let ptr =
-            unsafe { lv_win_add_title(self.obj.handle(), buf.as_ptr() as *const c_char) };
+        // SAFETY: handle non-null (constructor guarantees); with_cstr supplies a
+        // NUL-terminated buffer valid for the call; LVGL copies the text into an
+        // internal label.
+        let ptr = with_cstr(txt, |p| unsafe { lv_win_add_title(self.obj.handle(), p) });
         assert!(!ptr.is_null(), "lv_win_add_title returned NULL");
         Child::new(Obj::from_raw(ptr))
     }

--- a/tests/integration/widgets_display.rs
+++ b/tests/integration/widgets_display.rs
@@ -6,7 +6,8 @@ use oxivgl::style::{
     Selector, color_make,
 };
 use oxivgl::widgets::{
-    AnimImg, ArcLabel, ArcLabelDir, Button, Image, Label, Led, Line, Screen, ValueLabel,
+    AnimImg, ArcLabel, ArcLabelDir, Button, Checkbox, Image, Label, Led, Line, Screen, Textarea,
+    ValueLabel,
 };
 
 // ── Screen ───────────────────────────────────────────────────────────────────
@@ -207,15 +208,45 @@ fn image_set_src_symbol() {
     pump();
 }
 
-// ── Label::text_long / LabelLongMode variants ─────────────────────────────────
+// ── Long-text setters (issue #105: no silent truncation at 127 bytes) ─────────
+
+/// A 300-byte string — well past the old fixed 128-byte stack buffer.
+const LONG_TEXT: &str = "The quick brown fox jumps over the lazy dog. \
+    The quick brown fox jumps over the lazy dog. \
+    The quick brown fox jumps over the lazy dog. \
+    The quick brown fox jumps over the lazy dog. \
+    The quick brown fox jumps over the lazy dog. \
+    The quick brown fox jumps over the lazy dog.";
 
 #[test]
-fn label_text_long() {
+fn label_long_text_no_panic() {
     let screen = fresh_screen();
     let lbl = Label::new(&screen).unwrap();
-    lbl.text_long("A much longer string that would overflow the 127-byte stack buffer in text()");
+    assert!(LONG_TEXT.len() > 127);
+    lbl.text(LONG_TEXT);
     pump();
     assert!(lbl.get_width() > 0);
+}
+
+#[test]
+fn textarea_long_text_roundtrips_in_full() {
+    let screen = fresh_screen();
+    let ta = Textarea::new(&screen).unwrap();
+    assert!(LONG_TEXT.len() > 127);
+    ta.set_text(LONG_TEXT);
+    pump();
+    // The whole string must survive — not the first 127 bytes (issue #105).
+    assert_eq!(ta.get_text(), Some(LONG_TEXT));
+}
+
+#[test]
+fn checkbox_long_text_roundtrips_in_full() {
+    let screen = fresh_screen();
+    let cb = Checkbox::new(&screen).unwrap();
+    assert!(LONG_TEXT.len() > 127);
+    cb.text(LONG_TEXT);
+    pump();
+    assert_eq!(cb.get_text(), Some(LONG_TEXT));
 }
 
 #[test]


### PR DESCRIPTION
Fixes #105.

## Problem

Every `&str`-taking text setter copied through a fixed `[u8; 128]` stack buffer with `len = text.len().min(127)` — silently dropping everything past 127 bytes. No error, no panic, the text just stopped. Hit in oxicharge's session-terminal spike: a ~350-byte log fed to `Textarea::set_text` rendered only its first ~5 lines, costing a debugging round.

15 call sites across 8 widgets were affected: `Textarea::{set_text, add_text, set_placeholder_text}`, `Label::text`, `Checkbox::text`, `List::{add_text, add_button}`, `Msgbox::{add_title, add_text, add_footer_button}`, `Table::set_cell_value`, `Win::add_title`, `Menu::page_create`, `Label::set_translation_tag`, and the `Label::bind_text_map` updater.

## Fix

One shared `with_cstr()` helper (in `widgets/mod.rs`) builds a heap-backed NUL-terminated copy and hands the pointer to a closure. Every LVGL setter wrapped here copies the string into the widget's own storage before returning, so the temporary is freed immediately. Result: **no length cap**, and the per-call 128-byte stack temporary is removed from every widget constructor — which also trims the render task's worst-case stack frame (relevant to #107).

`Label::text` is now itself uncapped, so `Label::text_long` is **deprecated** as a redundant alias. Examples and the existing long-text test migrated to `text()`.

## Tests

- Added round-trip regression tests asserting a 300-byte string survives **verbatim** through `Textarea` and `Checkbox` (`assert_eq!(get_text(), Some(LONG_TEXT))`) — the old code would truncate to 127 and fail.
- Full suite green: unit 38, integration 531, leak 65, doc tests.
- Screenshots of the 5 migrated examples verified unchanged (the lone widget_label1 pixel diff is a 150×14px `ScrollCircular` animation-phase band, not a content change).

## Note (out of scope)

A pre-existing `unused_unsafe` warning at `tests/integration/anim.rs:39` (`pause_for` became safe) is left untouched here — flagging for a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)