### PR TITLE
feat: gate built-in font consts to faces enabled in lv_conf.h (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Built-in font constants are now gated to the faces enabled in `lv_conf.h`**
+  (#106). `src/fonts.rs` previously referenced every `lv_font_montserrat_*`
+  (8–48), the DejaVu Persian/Hebrew face, and both Source Han CJK faces
+  unconditionally, so disabling *any* of them in an application's `lv_conf.h`
+  broke `oxivgl`'s own compile (`cannot find value …` deep in the bindings) —
+  forcing every app to ship ~400 KiB of fonts it may not use. `oxivgl-sys`
+  (now **0.2.2**) reports which faces the LVGL build exposed, and each `Font`
+  const is gated behind a `font_*` cfg derived from that report. Apps can now
+  set `LV_FONT_* 0` to drop unused faces; referencing a disabled face is a
+  plain "cannot find value" error pointing at the app's own code. Requires
+  `oxivgl-sys >= 0.2.2`. (The previous `fonts` module docs claiming a *linker*
+  error and "no code-size cost" were wrong and have been corrected.)
+
 ### Fixed
 
 - **Text setters no longer silently truncate at 127 bytes** (#105). Every

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ log-04 = ["dep:log-04"]
 png = ["dep:png"]
 
 [dependencies]
-oxivgl_sys = { package = "oxivgl-sys", version = "0.2.1", path = "oxivgl-sys", default-features = false }
+oxivgl_sys = { package = "oxivgl-sys", version = "0.2.2", path = "oxivgl-sys", default-features = false }
 embassy-sync = "0.8"
 embassy-time = "0.5.0"
 heapless = { version = "0.9.1", features = ["nightly"] }
@@ -59,7 +59,7 @@ exclude = ["examples/common", "oxivgl-build", "oxivgl-sys"]
 
 [dev-dependencies]
 oxivgl-examples-common = { path = "examples/common" }
-oxivgl_sys = { package = "oxivgl-sys", version = "0.2.1", path = "oxivgl-sys", default-features = false }
+oxivgl_sys = { package = "oxivgl-sys", version = "0.2.2", path = "oxivgl-sys", default-features = false }
 
 # Proc-macro crates needed by fire27_main! attribute/macro expansion on xtensa
 [target.'cfg(target_arch = "xtensa")'.dev-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,38 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
+/// Built-in LVGL font faces that may be disabled in the application's
+/// `lv_conf.h`. Must match `GATED_FONTS` in `oxivgl-sys/build.rs` and the
+/// `#[cfg(font_*)]`-gated consts in `src/fonts.rs`.
+const GATED_FONTS: &[&str] = &[
+    "montserrat_8", "montserrat_10", "montserrat_12", "montserrat_14",
+    "montserrat_16", "montserrat_18", "montserrat_20", "montserrat_22",
+    "montserrat_24", "montserrat_26", "montserrat_28", "montserrat_30",
+    "montserrat_32", "montserrat_34", "montserrat_36", "montserrat_38",
+    "montserrat_40", "montserrat_42", "montserrat_44", "montserrat_46",
+    "montserrat_48", "dejavu_16_persian_hebrew", "source_han_sans_sc_14_cjk",
+    "source_han_sans_sc_16_cjk",
+];
+
+/// Turn the `DEP_LV_FONT_<NAME>` metadata emitted by `oxivgl-sys` (which knows
+/// exactly which font symbols the LVGL build exposed) into `font_<name>` cfgs,
+/// so `src/fonts.rs` compiles a `Font` const only for faces that actually
+/// exist. Declares every possible flag with `rustc-check-cfg` so the disabled
+/// ones don't trip the `unexpected_cfgs` lint.
+fn emit_font_cfgs() {
+    for name in GATED_FONTS {
+        println!("cargo::rustc-check-cfg=cfg(font_{name})");
+        let dep = format!("DEP_LV_FONT_{}", name.to_uppercase());
+        if std::env::var_os(&dep).is_some() {
+            println!("cargo::rustc-cfg=font_{name}");
+        }
+    }
+}
+
 fn main() {
+    // Font gating must run on every build (including docs.rs) so the `Font`
+    // consts match the symbols `oxivgl-sys` exposed.
+    emit_font_cfgs();
+
     // docs.rs has no lv_conf.h and oxivgl-sys skips C compilation under DOCS_RS,
     // so skip image asset generation here too — only Rust docs need to render.
     if std::env::var("DOCS_RS").is_ok() {

--- a/oxivgl-sys/Cargo.toml
+++ b/oxivgl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxivgl-sys"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Raw LVGL v9.5 FFI bindings for oxivgl — compiled from source with bindgen"

--- a/oxivgl-sys/build.rs
+++ b/oxivgl-sys/build.rs
@@ -12,6 +12,56 @@ use sha2::{Digest, Sha256};
 const LVGL_VERSION: &str = "9.5.0";
 const LVGL_SHA256: &str = "34a955cdf3a2d005507b704e87357af669a114523b6d3f77b5344fdc68717bc6";
 
+/// Built-in LVGL font faces that the application may disable in its `lv_conf.h`.
+/// Each entry is the `lv_font_<NAME>` suffix; a face is "available" only when
+/// its `LV_FONT_*` option is enabled, in which case bindgen emits the matching
+/// `extern static` and we surface a `font_<NAME>` flag for `oxivgl` to gate on.
+/// Keep in sync with the list in `oxivgl/build.rs` and the consts in
+/// `oxivgl/src/fonts.rs`.
+const GATED_FONTS: &[&str] = &[
+    "montserrat_8", "montserrat_10", "montserrat_12", "montserrat_14",
+    "montserrat_16", "montserrat_18", "montserrat_20", "montserrat_22",
+    "montserrat_24", "montserrat_26", "montserrat_28", "montserrat_30",
+    "montserrat_32", "montserrat_34", "montserrat_36", "montserrat_38",
+    "montserrat_40", "montserrat_42", "montserrat_44", "montserrat_46",
+    "montserrat_48", "dejavu_16_persian_hebrew", "source_han_sans_sc_14_cjk",
+    "source_han_sans_sc_16_cjk",
+];
+
+/// Inspect the generated `bindings.rs` and emit a `cargo:font_<NAME>=1`
+/// metadata value for every built-in font whose `extern static` is present.
+/// Via `links = "lv"` this reaches `oxivgl`'s build script as
+/// `DEP_LV_FONT_<NAME>`, which it turns into a `font_<NAME>` cfg. Using the
+/// generated bindings as the source of truth means the flag matches symbol
+/// availability exactly — including faces left at their `lv_conf_internal.h`
+/// default rather than spelled out in the app's `lv_conf.h`.
+fn emit_font_flags(bindings_path: &Path) {
+    let src = std::fs::read_to_string(bindings_path).unwrap_or_default();
+    for name in GATED_FONTS {
+        if contains_ident(&src, &format!("lv_font_{name}")) {
+            println!("cargo:font_{name}=1");
+        }
+    }
+}
+
+/// True if `ident` occurs in `src` as a whole identifier — i.e. not
+/// immediately followed by another identifier character. Robust to bindgen's
+/// spacing (`lv_font_x :` vs `lv_font_x:`) and collision-free across numeric
+/// suffixes (`montserrat_4` does not match `montserrat_40`).
+fn contains_ident(src: &str, ident: &str) -> bool {
+    let bytes = src.as_bytes();
+    let mut from = 0;
+    while let Some(pos) = src[from..].find(ident) {
+        let end = from + pos + ident.len();
+        let next = bytes.get(end).copied().unwrap_or(b' ');
+        if !next.is_ascii_alphanumeric() && next != b'_' {
+            return true;
+        }
+        from = end;
+    }
+    false
+}
+
 /// Download and extract LVGL source tree into `out_dir/lvgl-{version}/`.
 /// Returns the path to the extracted LVGL root.
 /// Respects `LVGL_SRC_DIR` env var override for local development.
@@ -83,11 +133,10 @@ fn main() {
     if env::var("DOCS_RS").is_ok() {
         let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
         let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-        std::fs::copy(
-            manifest_dir.join("bindings_docsrs.rs"),
-            out_path.join("bindings.rs"),
-        )
-        .expect("failed to install bundled bindings_docsrs.rs");
+        let bindings_path = out_path.join("bindings.rs");
+        std::fs::copy(manifest_dir.join("bindings_docsrs.rs"), &bindings_path)
+            .expect("failed to install bundled bindings_docsrs.rs");
+        emit_font_flags(&bindings_path);
         return;
     }
 
@@ -374,6 +423,10 @@ fn main() {
     // bindgen 0.72 emits `transmute` for signed↔unsigned bitfield casts;
     // newer rustc warns (unnecessary_transmutes). Patch to use direct casts.
     fix_bindgen_transmutes(&bindings_path);
+
+    // Surface which built-in fonts actually made it into the bindings so
+    // `oxivgl` can gate its font consts and avoid forcing every face on.
+    emit_font_flags(&bindings_path);
 
     cfg.file(out_path.join("static_fns.c"));
     cfg.compile("lvgl");

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -3,16 +3,19 @@
 //!
 //! # Font availability
 //!
-//! The `MONTSERRAT_*` constants (and other built-in font statics) reference
-//! `extern "C"` symbols that are compiled into the LVGL binary **only when the
-//! corresponding `LV_FONT_MONTSERRAT_*` option is enabled** in the
-//! application's `lv_conf.h`.
+//! Each built-in font constant — the `MONTSERRAT_*` sizes,
+//! `DEJAVU_16_PERSIAN_HEBREW`, and the Source Han CJK faces — exists **only
+//! when the matching `LV_FONT_*` option is enabled** in the application's
+//! `lv_conf.h`. The `oxivgl-sys` build script reports which faces the LVGL
+//! build actually exposed, and each constant here is gated behind a `font_*`
+//! cfg derived from that report.
 //!
-//! Referencing a font that was not enabled causes a **linker error** at build
-//! time — fail-fast, not undefined behaviour.  Applications must ensure their
-//! `lv_conf.h` enables every font they intend to use.  LTO removes unused font
-//! symbols automatically, so enabling extras you don't use has no code-size
-//! cost.
+//! This means an application can trim faces it doesn't use — each Montserrat
+//! size is several KiB of flash — by setting the corresponding `LV_FONT_* 0`,
+//! and `oxivgl` still compiles. Referencing a disabled face is then an
+//! ordinary "cannot find value" error pointing at your own code, instead of an
+//! opaque failure deep in the generated bindings. Keep `LV_FONT_DEFAULT` (and
+//! the face it points at) enabled.
 use core::cell::UnsafeCell;
 use core::mem::MaybeUninit;
 use core::ptr::addr_of;
@@ -62,15 +65,18 @@ impl Font {
 }
 
 /// LVGL built-in DejaVu 16 pt with Persian/Hebrew glyphs.
+#[cfg(font_dejavu_16_persian_hebrew)]
 pub static DEJAVU_16_PERSIAN_HEBREW: Font =
     Font(addr_of!(oxivgl_sys::lv_font_dejavu_16_persian_hebrew));
 
 
 /// LVGL built-in Source Han Sans SC 14 pt with CJK glyphs.
+#[cfg(font_source_han_sans_sc_14_cjk)]
 pub static SOURCE_HAN_SANS_SC_14_CJK: Font =
     Font(addr_of!(oxivgl_sys::lv_font_source_han_sans_sc_14_cjk));
 
 /// LVGL built-in Source Han Sans SC 16 pt with CJK glyphs.
+#[cfg(font_source_han_sans_sc_16_cjk)]
 pub static SOURCE_HAN_SANS_SC_16_CJK: Font =
     Font(addr_of!(oxivgl_sys::lv_font_source_han_sans_sc_16_cjk));
 
@@ -160,50 +166,73 @@ unsafe extern "C" fn fixed_width_get_glyph_dsc(
     }
 }
 
-// SAFETY: All lv_font_montserrat_* are valid static fonts compiled into the
-// binary (enabled via LV_FONT_MONTSERRAT_* in lv_conf.h). LTO removes unused.
+// SAFETY: each lv_font_montserrat_* is a valid static font that is present in
+// the bindings exactly when LV_FONT_MONTSERRAT_* is enabled — which is also
+// precisely when the `font_montserrat_*` cfg below is set, so each addr_of!
+// only ever names a symbol that exists.
 
 /// LVGL built-in Montserrat 8 pt.
+#[cfg(font_montserrat_8)]
 pub static MONTSERRAT_8: Font = Font(addr_of!(oxivgl_sys::lv_font_montserrat_8));
 /// LVGL built-in Montserrat 10 pt.
+#[cfg(font_montserrat_10)]
 pub static MONTSERRAT_10: Font = Font(addr_of!(oxivgl_sys::lv_font_montserrat_10));
 /// LVGL built-in Montserrat 12 pt.
+#[cfg(font_montserrat_12)]
 pub static MONTSERRAT_12: Font = Font(addr_of!(oxivgl_sys::lv_font_montserrat_12));
 /// LVGL built-in Montserrat 14 pt.
+#[cfg(font_montserrat_14)]
 pub static MONTSERRAT_14: Font = Font(addr_of!(oxivgl_sys::lv_font_montserrat_14));
 /// LVGL built-in Montserrat 16 pt.
+#[cfg(font_montserrat_16)]
 pub static MONTSERRAT_16: Font = Font(addr_of!(oxivgl_sys::lv_font_montserrat_16));
 /// LVGL built-in Montserrat 18 pt.
+#[cfg(font_montserrat_18)]
 pub static MONTSERRAT_18: Font = Font(addr_of!(oxivgl_sys::lv_font_montserrat_18));
 /// LVGL built-in Montserrat 20 pt.
+#[cfg(font_montserrat_20)]
 pub static MONTSERRAT_20: Font = Font(addr_of!(oxivgl_sys::lv_font_montserrat_20));
 /// LVGL built-in Montserrat 22 pt.
+#[cfg(font_montserrat_22)]
 pub static MONTSERRAT_22: Font = Font(addr_of!(oxivgl_sys::lv_font_montserrat_22));
 /// LVGL built-in Montserrat 24 pt.
+#[cfg(font_montserrat_24)]
 pub static MONTSERRAT_24: Font = Font(addr_of!(oxivgl_sys::lv_font_montserrat_24));
 /// LVGL built-in Montserrat 26 pt.
+#[cfg(font_montserrat_26)]
 pub static MONTSERRAT_26: Font = Font(addr_of!(oxivgl_sys::lv_font_montserrat_26));
 /// LVGL built-in Montserrat 28 pt.
+#[cfg(font_montserrat_28)]
 pub static MONTSERRAT_28: Font = Font(addr_of!(oxivgl_sys::lv_font_montserrat_28));
 /// LVGL built-in Montserrat 30 pt.
+#[cfg(font_montserrat_30)]
 pub static MONTSERRAT_30: Font = Font(addr_of!(oxivgl_sys::lv_font_montserrat_30));
 /// LVGL built-in Montserrat 32 pt.
+#[cfg(font_montserrat_32)]
 pub static MONTSERRAT_32: Font = Font(addr_of!(oxivgl_sys::lv_font_montserrat_32));
 /// LVGL built-in Montserrat 34 pt.
+#[cfg(font_montserrat_34)]
 pub static MONTSERRAT_34: Font = Font(addr_of!(oxivgl_sys::lv_font_montserrat_34));
 /// LVGL built-in Montserrat 36 pt.
+#[cfg(font_montserrat_36)]
 pub static MONTSERRAT_36: Font = Font(addr_of!(oxivgl_sys::lv_font_montserrat_36));
 /// LVGL built-in Montserrat 38 pt.
+#[cfg(font_montserrat_38)]
 pub static MONTSERRAT_38: Font = Font(addr_of!(oxivgl_sys::lv_font_montserrat_38));
 /// LVGL built-in Montserrat 40 pt.
+#[cfg(font_montserrat_40)]
 pub static MONTSERRAT_40: Font = Font(addr_of!(oxivgl_sys::lv_font_montserrat_40));
 /// LVGL built-in Montserrat 42 pt.
+#[cfg(font_montserrat_42)]
 pub static MONTSERRAT_42: Font = Font(addr_of!(oxivgl_sys::lv_font_montserrat_42));
 /// LVGL built-in Montserrat 44 pt.
+#[cfg(font_montserrat_44)]
 pub static MONTSERRAT_44: Font = Font(addr_of!(oxivgl_sys::lv_font_montserrat_44));
 /// LVGL built-in Montserrat 46 pt.
+#[cfg(font_montserrat_46)]
 pub static MONTSERRAT_46: Font = Font(addr_of!(oxivgl_sys::lv_font_montserrat_46));
 /// LVGL built-in Montserrat 48 pt.
+#[cfg(font_montserrat_48)]
 pub static MONTSERRAT_48: Font = Font(addr_of!(oxivgl_sys::lv_font_montserrat_48));
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #106. **Stacked on #108** (base `fix/text-setter-truncation`) — review/merge that first.

## Problem

`src/fonts.rs` took `addr_of!` of every `lv_font_montserrat_*` (8–48), the DejaVu Persian/Hebrew face, and both Source Han CJK faces **unconditionally**. bindgen only emits a font's binding when its `LV_FONT_*` option is enabled, so disabling any face in an app's `lv_conf.h` broke **oxivgl's own compile** (`cannot find value lv_font_… in crate oxivgl_sys`). Every app was therefore forced to enable all faces — ~400 KiB of flash oxicharge couldn't afford (its EVCC demo links 1.65 MiB, past the ~1.1 MiB probe-rs flash limit on CoreS3).

The old module docs compounded it: they claimed referencing a disabled font was a *linker* error and that "enabling extras you don't use has no code-size cost." Both were wrong.

## Fix

`oxivgl-sys` (bumped **0.2.1 → 0.2.2**) inspects the generated `bindings.rs` and emits a `cargo:font_<name>=1` metadata flag for each built-in face present. Via `links = "lv"` these reach `oxivgl`'s build script as `DEP_LV_FONT_<NAME>`, which turns them into `font_<name>` cfgs (with `rustc-check-cfg` for all 24). Each `Font` const in `fonts.rs` is gated behind its `font_*` cfg.

Using the **generated bindings as the source of truth** means the flags match symbol availability exactly — including faces left at their `lv_conf_internal.h` default rather than spelled out in `lv_conf.h`. `LV_FONT_DEFAULT`'s face must stay enabled.

## Validation (end-to-end)

Built with `LV_FONT_MONTSERRAT_8` + both CJK faces disabled:
- those symbols are **absent** from the generated bindings; `montserrat_14` still present;
- `oxivgl-sys` emits `font_montserrat_14=1` but **not** `font_montserrat_8`;
- **`oxivgl` compiles** (previously a hard error);
- `oxivgl::fonts::MONTSERRAT_8` now fails with a clean `cannot find value MONTSERRAT_8 in module oxivgl::fonts` pointing at user code.

Full suite green under the default (all-enabled) conf: unit 38, integration 531, leak 65, `--all-targets`, and `RUSTDOCFLAGS="-W missing-docs" cargo doc` → 0 warnings. docs.rs coverage unchanged (`default-conf` enables all faces).

## Publish note

`oxivgl-sys 0.2.2` must be published **before** the next `oxivgl` release (the `>= 0.2.2` requirement); otherwise a downstream resolving `oxivgl-sys 0.2.1` gets no font flags and every face gates out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)