### PR TITLE
perf: keep View::create/update out of run_app's task frame (#107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`run_app` no longer inlines `View::create` / `View::update` into the task
+  poll frame** (#107). Because `run_app` dispatches the view statically, under
+  the fat-LTO release profile both methods were inlined into the embassy task's
+  `poll`, so the Xtensa prologue sized the *persistent* task stack frame for
+  their worst-case widget-construction working set (measured at ~31.7 KiB on an
+  esp32s3 build) even though it is dead by the next `await`. Both calls now go
+  through `#[inline(never)]` boundaries, keeping each method's frame a transient
+  call frame released on return. No API or behaviour change; the navigator run
+  loop was already unaffected (it dispatches through `dyn AnyView`).
 - **Built-in font constants are now gated to the faces enabled in `lv_conf.h`**
   (#106). `src/fonts.rs` previously referenced every `lv_font_montserrat_*`
   (8–48), the DejaVu Persian/Hebrew face, and both Source Han CJK faces

--- a/src/view.rs
+++ b/src/view.rs
@@ -378,7 +378,7 @@ pub async fn run_app<V: View, const BYTES: usize>(
     assert!(!screen_handle.is_null(), "no active screen after display init");
     let container = Obj::from_raw_non_owning(screen_handle);
 
-    if let Err(e) = view.create(&container) {
+    if let Err(e) = create_view(&mut view, &container) {
         warn!("Could not create LVGL widgets: {:?}, disabling UI", e);
         loop {
             Timer::after(embassy_time::Duration::from_secs(60)).await;
@@ -389,7 +389,7 @@ pub async fn run_app<V: View, const BYTES: usize>(
 
     loop {
         debug!("Rendering UI loop iteration");
-        let action = view.update()
+        let action = update_view(&mut view)
             .unwrap_or_else(|e| { warn!("Failed to update widgets: {:?}", e); NavAction::None });
         debug_assert!(action.is_none(), "NavAction ignored in run_app — use run_app_nav for navigation");
 
@@ -408,6 +408,26 @@ pub async fn run_app<V: View, const BYTES: usize>(
         // run_app_nav). This simple run_app ignores actions —
         // use run_app_nav for multi-screen applications.
     }
+}
+
+// `run_app` dispatches `View::create` / `View::update` *statically*, so under
+// the crate's fat-LTO release profile they inline into the embassy task's
+// `poll`. The Xtensa `entry` prologue then sizes the **persistent** task frame
+// for their worst-case widget-construction stack — measured at ~31.7 KiB on an
+// esp32s3 build (issue #107) — even though that working set is dead by the next
+// `await`. Routing both calls through these `#[inline(never)]` boundaries keeps
+// each method's frame a *transient* call frame, released on return, instead of
+// being folded into the frame the task holds across every await. (The navigator
+// run loop already gets this for free: it calls `update` through a
+// `dyn AnyView`, an un-inlinable virtual dispatch.)
+#[inline(never)]
+fn create_view<V: View>(view: &mut V, container: &Obj<'static>) -> Result<(), WidgetError> {
+    view.create(container)
+}
+
+#[inline(never)]
+fn update_view<V: View>(view: &mut V) -> Result<NavAction, WidgetError> {
+    view.update()
 }
 
 /// Run the LVGL render loop with navigation support.


### PR DESCRIPTION
Addresses #107. **Draft — needs an on-target re-measure before merge.** Stacked on #109 (base `fix/font-conf-gating`).

## Finding

The report suspected "by-value display/buffer plumbing inside run_app." The code shows otherwise — **`run_app` is already lean**: `LvglDriver` is a ZST (`struct LvglDriver;`), `bufs` is a `&'static mut` (one pointer), `timer_handler` has no locals, and the loop locals are pointer-sized. There is no large working set to hoist.

The ~31.7 KiB comes from **inlining**. `run_app` dispatches `View::create`/`View::update` *statically*, so under the crate's `lto = "fat"` + `codegen-units = 1` release profile they fold into the embassy task's `…poll`. Xtensa's `entry` reserves one frame sized to the worst-case point across that union — the view's widget-construction stack — and the task holds it for its whole life, even though it's dead by the next `await`. (The navigator run loop already avoids this: it calls `update` through a `dyn AnyView`, an un-inlinable virtual dispatch — which is why the report saw the bloat in `run_app` specifically.)

## Change

Route both calls through `#[inline(never)]` boundaries (`create_view` / `update_view`). The boundary is ABI-level, so each method's frame becomes a transient call frame released on return, instead of inflating the persistent poll frame. No API or behaviour change; `create` is called once and `update` ~30×/s, so the extra call is negligible.

## What's verified vs. not

- ✅ Host build + full suite unchanged (unit 38, integration 531, leak 65, `--all-targets`).
- ✅ Behaviour identical (pure structural change).
- ⚠️ **Magnitude unverified** — the host build has no Xtensa prologue. Please re-run the prologue scan on the esp32s3 session-terminal demo and confirm the `run_app::<View, BUF>` poll frame drops:

```sh
objdump -d <elf> | awk '/^[0-9a-f]+ <.*>:/{f=$2} /entry\ta1,/{print $NF, f}' | sort -rn | head
```

If the drop is smaller than hoped, the residual is likely inside the view's own `create`/`update` (now in their own frames) or an LVGL C frame — happy to iterate with the new numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)