### PR TITLE
chore: enforce zero-warnings policy via Cargo [lints] table

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,3 +79,8 @@ incremental = false
 lto = "fat"
 opt-level = "s"
 overflow-checks = true
+
+# Zero-warnings policy: any rustc warning is a hard build error (local + CI,
+# host + xtensa). Equivalent to `-D warnings`, scoped to this crate's own code.
+[lints.rust]
+warnings = "deny"

--- a/examples/common/Cargo.toml
+++ b/examples/common/Cargo.toml
@@ -32,3 +32,8 @@ lcd-async            = "0.1.1"
 log                  = "0.4"
 static_cell          = { version = "2.1.1", features = ["nightly"] }
 async-button         = "0.2.0"
+
+# Zero-warnings policy: any rustc warning is a hard build error.
+# Equivalent to `-D warnings`, scoped to this crate's own code.
+[lints.rust]
+warnings = "deny"

--- a/oxivgl-build/Cargo.toml
+++ b/oxivgl-build/Cargo.toml
@@ -14,4 +14,9 @@ categories = ["development-tools::build-utils"]
 [dependencies]
 cc = "1"
 
+# Zero-warnings policy: any rustc warning is a hard build error.
+# Equivalent to `-D warnings`, scoped to this crate's own code.
+[lints.rust]
+warnings = "deny"
+
 [workspace]

--- a/oxivgl-sys/Cargo.toml
+++ b/oxivgl-sys/Cargo.toml
@@ -33,4 +33,9 @@ features = []
 targets = ["x86_64-unknown-linux-gnu"]
 no-default-features = true
 
+# Zero-warnings policy: any rustc warning is a hard build error.
+# Equivalent to `-D warnings`, scoped to this crate's own code.
+[lints.rust]
+warnings = "deny"
+
 [workspace]

--- a/tests/integration/anim.rs
+++ b/tests/integration/anim.rs
@@ -35,8 +35,8 @@ fn anim_pause_for_during_animation() {
     let handle = a.start();
     pump();
 
-    // SAFETY: animation just started (1000 ms), guaranteed still running.
-    unsafe { handle.pause_for(500) };
+    // animation just started (1000 ms), guaranteed still running.
+    handle.pause_for(500);
     pump();
 }
 


### PR DESCRIPTION
Adds `[lints.rust] warnings = "deny"` to all four workspace crates
(`oxivgl`, `oxivgl-sys`, `oxivgl-build`, `oxivgl-examples-common`), so any
rustc warning is a hard build error locally **and** in CI, across host and
xtensa targets — the Cargo-native equivalent of `-D warnings`, scoped to our
own code.

### Why the `[lints]` table (not `RUSTFLAGS`/`.cargo/config.toml`)
- **Honored by every `cargo` invocation** (local dev, CI, all targets) — no
  need to remember an env var or duplicate flags per target.
- **Scoped to our code, not dependencies** — avoids spurious breakage from a
  dependency's warnings (which `RUSTFLAGS=-D warnings` would deny too).
- **Downstream-safe** — Cargo ignores a crate's lints table when it is consumed
  as a *registry* dependency, so a future compiler that adds a new warning to
  our code cannot break consumers building `oxivgl` from crates.io.

### Bycatch
Fixes the single pre-existing violation this surfaces: an unnecessary `unsafe`
block around the now-safe `Anim::pause_for` in `tests/integration/anim.rs`
(flagged for separate cleanup in the #108–#110 PRs).

Verified: full `cargo check --all-targets` is clean under the new lints;
injecting an `unused_variable` turns into a hard `error:` as expected. Unit
(40), integration (535), and leak (65) suites all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)