### PR TITLE
fix: Restore leak-check compilation, make CI and the doc audit able to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,11 +82,13 @@ jobs:
             --target x86_64-unknown-linux-gnu -- --test-threads=1
 
       # Was never in CI, which is how leak_check.rs came to stop compiling on
-      # master unnoticed.
+      # master unnoticed. `--nocapture` is required: without it libtest buffers
+      # output in memory and LVGL's log callback allocates inside the
+      # measurement window, reporting ~88 bytes/iter of phantom leak everywhere.
       - name: Leak detection tests
         run: |
           SDL_VIDEODRIVER=dummy cargo +nightly test --test leak_check \
-            --target x86_64-unknown-linux-gnu -- --test-threads=1
+            --target x86_64-unknown-linux-gnu -- --test-threads=1 --nocapture
 
       # Catches undocumented public items *and* doc-build failures. A broken
       # intra-doc link produces no HTML at all, which previously shipped a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,19 @@ jobs:
           SDL_VIDEODRIVER=dummy cargo +nightly test --test integration \
             --target x86_64-unknown-linux-gnu -- --test-threads=1
 
+      # Was never in CI, which is how leak_check.rs came to stop compiling on
+      # master unnoticed.
+      - name: Leak detection tests
+        run: |
+          SDL_VIDEODRIVER=dummy cargo +nightly test --test leak_check \
+            --target x86_64-unknown-linux-gnu -- --test-threads=1
+
+      # Catches undocumented public items *and* doc-build failures. A broken
+      # intra-doc link produces no HTML at all, which previously shipped a
+      # module missing from docs.rs without failing anything.
+      - name: Doc coverage and link check
+        run: ./run_docs.sh --check
+
       - name: Run all examples (headless screenshots)
         run: ./run_host.sh -s
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,11 @@ cargo +esp -Zbuild-std=alloc,core check --target xtensa-esp32-none-elf --feature
 cargo test to_lvgl_half
 
 # Audit doc coverage (should report 0 missing):
-RUSTDOCFLAGS="-W missing-docs" cargo doc --no-deps 2>&1 | grep "warning:"
+./run_docs.sh --check   # fails on undocumented items AND on doc-build errors
+
+# Do NOT audit with `cargo doc ... | grep "warning:"` — broken intra-doc links
+# are `error:`, and a failed doc build produces no HTML at all, so that pipeline
+# reports a clean audit while the module is silently absent from the docs.
 
 # Run host example (interactive SDL window):
 ./run_host.sh getting_started1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ oxivgl_sys = { package = "oxivgl-sys", version = "0.2.2", path = "oxivgl-sys", d
 [target.'cfg(target_arch = "xtensa")'.dev-dependencies]
 embassy-executor       = { version = "0.10.0", features = ["nightly"] }
 esp-bootloader-esp-idf = { version = "0.5.0", features = ["esp32"] }
-esp-hal                = { version = "=1.1.0", features = ["esp32", "unstable"] }
+esp-hal                = { version = "=1.1.1", features = ["esp32", "unstable"] }
 esp-rtos               = { version = "0.3.0", features = ["esp32", "embassy"] }
 
 [profile.dev]

--- a/examples/common/Cargo.toml
+++ b/examples/common/Cargo.toml
@@ -20,7 +20,7 @@ oxivgl_sys = { package = "oxivgl-sys", path = "../../oxivgl-sys", default-featur
 esp-alloc            = { version = "0.10.0", features = ["esp32", "internal-heap-stats"] }
 esp-backtrace        = { version = "0.18.1", features = ["esp32", "panic-handler", "custom-halt", "colors", "println"] }
 esp-bootloader-esp-idf = { version = "0.5.0", features = ["esp32"] }
-esp-hal              = { version = "=1.1.0", features = ["esp32", "unstable"] }
+esp-hal              = { version = "=1.1.1", features = ["esp32", "unstable"] }
 esp-println          = { version = "0.16.1", features = ["esp32", "log-04", "colors", "uart"], default-features = false }
 esp-rtos             = { version = "0.3.0", features = ["esp32", "embassy"] }
 esp-sync             = { version = "0.2.1", features = ["esp32"] }

--- a/run_docs.sh
+++ b/run_docs.sh
@@ -20,12 +20,35 @@ for arg in "$@"; do
 done
 
 if [ "$CHECK" -eq 1 ]; then
-    RUSTDOCFLAGS="-W missing-docs" \
+    # Capture rather than pipe. Two traps this avoids:
+    #  - Broken intra-doc links are `error:`, not `warning:`, and a failed doc
+    #    build emits no HTML at all — so grepping only for "warning:" reports a
+    #    clean audit while the module you just added is missing from the docs.
+    #  - Piping discards cargo's exit status, and the old `|| true; exit 0` made
+    #    this check incapable of ever failing.
+    # `set -e` would abort at the capture on a failed doc build, printing
+    # nothing at all — so suspend it and handle the status explicitly.
+    set +e
+    out=$(RUSTDOCFLAGS="-W missing-docs" \
         cargo +nightly doc \
             --target "$TARGET" \
             --no-deps \
             -j1 \
-            2>&1 | grep "warning:" || true
+            2>&1)
+    status=$?
+    set -e
+
+    echo "$out" | grep -E "^(error|warning)" || true
+
+    if [ "$status" -ne 0 ]; then
+        echo "FAIL: doc build failed — see errors above" >&2
+        exit 1
+    fi
+    if echo "$out" | grep -q "warning:"; then
+        echo "FAIL: undocumented public items" >&2
+        exit 1
+    fi
+    echo "Doc check passed: build succeeded, no undocumented public items."
     exit 0
 fi
 

--- a/tests/leak_check.rs
+++ b/tests/leak_check.rs
@@ -15,6 +15,7 @@
 #![allow(deprecated)]
 
 use std::alloc::{GlobalAlloc, Layout, System};
+use std::ffi::{c_char, c_void};
 use std::sync::atomic::{AtomicIsize, Ordering};
 
 // ── Counting allocator ───────────────────────────────────────────────────────
@@ -77,12 +78,15 @@ fn run_isolated(name: &str, test_fn: fn() -> isize) {
     use std::io::Read;
     use std::os::unix::io::FromRawFd;
 
+    // Signatures must match libc exactly — rustc denies redeclaring a symbol the
+    // standard library's runtime also uses (`write`, `open`) with a divergent
+    // signature. Keep the `c_void` / `c_char` types and `open`'s varargs.
     unsafe extern "C" {
         fn pipe(fds: *mut i32) -> i32;
         fn fork() -> i32;
         fn _exit(status: i32) -> !;
         fn close(fd: i32) -> i32;
-        fn write(fd: i32, buf: *const u8, count: usize) -> isize;
+        fn write(fd: i32, buf: *const c_void, count: usize) -> isize;
         fn waitpid(pid: i32, status: *mut i32, options: i32) -> i32;
     }
 
@@ -98,8 +102,8 @@ fn run_isolated(name: &str, test_fn: fn() -> isize) {
         unsafe { close(read_fd) };
 
         // Silence child output to avoid confusing the test harness
-        unsafe extern "C" { fn open(path: *const u8, flags: i32) -> i32; fn dup2(old: i32, new: i32) -> i32; }
-        let devnull = unsafe { open(b"/dev/null\0".as_ptr(), 2) }; // O_RDWR=2
+        unsafe extern "C" { fn open(path: *const c_char, flags: i32, ...) -> i32; fn dup2(old: i32, new: i32) -> i32; }
+        let devnull = unsafe { open(c"/dev/null".as_ptr(), 2) }; // O_RDWR=2
         if devnull >= 0 {
             unsafe { dup2(devnull, 1); dup2(devnull, 2); close(devnull); }
         }
@@ -110,7 +114,7 @@ fn run_isolated(name: &str, test_fn: fn() -> isize) {
         let per_iter = test_fn();
 
         let bytes = per_iter.to_le_bytes();
-        unsafe { write(write_fd, bytes.as_ptr(), bytes.len()) };
+        unsafe { write(write_fd, bytes.as_ptr().cast::<c_void>(), bytes.len()) };
         unsafe { close(write_fd) };
         unsafe { _exit(0) };
     }

--- a/tests/leak_check.rs
+++ b/tests/leak_check.rs
@@ -9,7 +9,13 @@
 //! After N create/destroy iterations, net allocation must be zero.
 //!
 //! Run with: `SDL_VIDEODRIVER=dummy cargo +nightly test --test leak_check
-//!   --target x86_64-unknown-linux-gnu -- --test-threads=1`
+//!   --target x86_64-unknown-linux-gnu -- --test-threads=1 --nocapture`
+//!
+//! **`--nocapture` is mandatory, not cosmetic.** Without it libtest captures
+//! stdout/stderr into a growing in-memory buffer, and LVGL's log callback
+//! (`eprintln!` on host) writes into that buffer *inside* the measurement
+//! window — so every test reports a uniform ~88 bytes/iter of phantom leak.
+//! Use `./run_tests.sh leak`, which passes it.
 
 // Tests exercise the deprecated inline style setters to verify they still work.
 #![allow(deprecated)]

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,9 @@
+# tools/
+
+Curated, reusable maintenance helpers. Not a junk drawer — one-off scripts
+belong in the gitignored `work/`, and a tool that stops being used should be
+deleted rather than left to rot.
+
+| Tool | Purpose |
+|------|---------|
+| [`regen-docsrs-bindings.sh`](regen-docsrs-bindings.sh) | Refresh `oxivgl-sys/bindings_docsrs.rs`, the pre-generated bindings docs.rs uses because it has no network access. **Run this whenever `oxivgl-sys/default-conf/lv_conf.h` changes.** A stale snapshot does not fail any build — it silently publishes documentation with modules missing. |

--- a/tools/regen-docsrs-bindings.sh
+++ b/tools/regen-docsrs-bindings.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Regenerate oxivgl-sys/bindings_docsrs.rs.
+#
+# docs.rs has no network access, so `oxivgl-sys` cannot download LVGL or run
+# bindgen there. Under DOCS_RS it uses this committed snapshot instead and skips
+# the download + cc compilation entirely (build.rs, the DOCS_RS branch).
+#
+# The snapshot therefore has to be refreshed whenever `default-conf/lv_conf.h`
+# changes anything bindgen surfaces — fonts, widget enables, and in particular
+# `LV_USE_STDLIB_MALLOC`, which gates whether `oxivgl::mem` is compiled at all.
+# A stale snapshot does not fail the build: it silently publishes docs that are
+# missing modules. That is exactly what happened when the allocator moved to
+# LV_STDLIB_BUILTIN and the snapshot still reported CLIB.
+#
+# Generated from `default-conf`, not `examples/conf`: the snapshot should
+# reflect what a consumer gets with the shipped default, not this repo's
+# example/test configuration.
+#
+# Usage: ./tools/regen-docsrs-bindings.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+TARGET="x86_64-unknown-linux-gnu"
+CONF="$PWD/oxivgl-sys/default-conf"
+OUT="$PWD/oxivgl-sys/bindings_docsrs.rs"
+
+echo "Regenerating $OUT from $CONF"
+
+# build.rs does not declare rerun-if-env-changed for DEP_LV_CONFIG_PATH, so a
+# changed config alone will not re-run it. Force it.
+touch oxivgl-sys/build.rs
+
+DEP_LV_CONFIG_PATH="$CONF" cargo build -p oxivgl-sys --target "$TARGET"
+
+generated=$(find "target/$TARGET" -path '*/oxivgl-sys-*/out/bindings.rs' \
+    -newer oxivgl-sys/build.rs -print0 2>/dev/null \
+    | xargs -0 ls -t 2>/dev/null | head -1)
+
+if [ -z "$generated" ]; then
+    echo "error: no freshly generated bindings.rs found" >&2
+    exit 1
+fi
+
+cp "$generated" "$OUT"
+echo "Copied $generated"
+
+# Sanity-check the one setting whose drift silently removes a module from the
+# published docs.
+backend=$(grep -oE 'LV_USE_STDLIB_MALLOC *: u32 = [0-9]+' "$OUT" | grep -oE '[0-9]+$')
+builtin=$(grep -oE 'LV_STDLIB_BUILTIN *: u32 = [0-9]+' "$OUT" | grep -oE '[0-9]+$')
+if [ "$backend" = "$builtin" ]; then
+    echo "OK: allocator backend is LV_STDLIB_BUILTIN — oxivgl::mem will be documented"
+else
+    echo "NOTE: allocator backend is not BUILTIN — oxivgl::mem will NOT appear on docs.rs"
+fi
+
+# Leave the tree building against the workspace default again.
+touch oxivgl-sys/build.rs
+echo "Done. Rebuild normally before running tests."


### PR DESCRIPTION
Bycatch from the PSRAM work (#117), split out because none of it depends on that
feature and two items are fixes to problems already on `master`.

## `tests/leak_check.rs` did not compile on master

Two hand-declared libc externs diverged from their real signatures, which newer
rustc rejects via `invalid_runtime_symbol_definitions` (deny-by-default) and
`suspicious_runtime_symbol_definitions`. `./run_tests.sh leak` failed outright.

## The leak suite was never in CI

Which is how the above went unnoticed. 65 tests, unexercised. Now run in CI —
**with `--nocapture`, which is load-bearing**: without it libtest buffers output
in memory and LVGL's log callback allocates *inside* the measurement window, so
every test reports an identical ~88 bytes/iter of phantom leak. That is not
hypothetical — adding the step without the flag failed 52 of 65 on its first CI
run, reproduced locally before fixing. `run_tests.sh` already passed it; the
module's own documented "Run with:" line did not, and that is where the CI
invocation was copied from. Both now state why.

## The doc audit could not fail

`run_docs.sh --check` piped rustdoc into `grep "warning:"` then `|| true; exit
0`, discarding both every `error:` line and the exit status. Broken intra-doc
links are errors, and a failed doc build emits no HTML at all — so the audit
reported a clean run while a whole module was missing from the generated docs.
It now captures the output, prints errors and warnings, and exits non-zero on
either.

Negative-controlled: a deliberately broken link fails with the link named and
exit 1; the restored tree passes. (That control caught a bug in the fix itself —
`set -e` aborted at the capture and printed nothing.)

CI additionally gains the doc check.

## esp-hal to `=1.1.1`

Aligns with `m5stack-core`, which pins `=1.1.1`; two differing exact pins cannot
coexist. This is one of the two blockers to oxivgl's examples using the BSP for
board bring-up, and thereby getting ESP32-S3 support without duplicating drivers
(#119). The other blocker — `m5stack-core` depending on `oxivgl`, so a
dev-dependency needs `[patch.crates-io]` to avoid a second LVGL compilation —
is unchanged.

## Verification

Standalone on this branch: 55 unit, 40 doc, 65 leak, doc check clean. ESP32
example builds against esp-hal 1.1.1.

Bottom of a 2-PR stack; #117 targets this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUdpbjrVH5RBkoo2tEE39Y
