### PR TITLE
release: v0.6.1 — render-scratch fix (#124) + nav-spec reconcile (#123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.6.1] — Unreleased
+## [0.6.1] — 2026-07-21
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] — Unreleased
+
+### Fixed
+
+- **Transient per-frame render scratch no longer leaks into a PSRAM pool**
+  (#124). The software renderer allocates a scratch buffer per draw op, every
+  frame — draw-task descriptors (`lv_draw_add_task`), scanline masks (arc, line,
+  fill, border, triangle, rect-mask), box-shadow blur/mask buffers, and image
+  mask/transform buffers — through a plain `lv_malloc`/`lv_free` with no callback
+  hook (unlike draw buffers). Once a runtime pool was registered this scratch
+  became eligible to land in it; when the pool is PSRAM, serving that per-frame
+  churn against PSRAM-resident TLSF metadata halved the meter-screen render on
+  ESP32 (16 → 7 FPS, measured downstream). `oxivgl-sys` now patches the SW draw
+  sources to route these allocations through
+  `oxivgl_render_scratch_{malloc,zalloc,free}`, which keep them in internal DRAM
+  while a pool is active — the direct analogue of the existing draw-buffer guard,
+  extended from pixel buffers to all transient render scratch. So the whole
+  render hot path stays internal while the persistent widget tree lives in PSRAM,
+  making render cost track dirty-region complexity rather than total UI size.
+  The radius/circle mask cache (`lv_draw_sw_mask.c`), read per-scanline every
+  frame by arc, rounded-rect, border and shadow draws, is routed too — its
+  alloc/free sites are all self-contained in that file, so it is as safe to route
+  as the per-frame scratch. LVGL's gradient cache (`lv_draw_sw_grad.c`) is left on
+  LVGL's allocator: gradient-only and cross-function with multi-path frees. With
+  no pool registered (or under `LV_STDLIB_CLIB`) the calls delegate straight to
+  LVGL's allocator, so behaviour is unchanged. Requires `oxivgl-sys 0.2.4`.
+
 ## [0.6.0] — 2026-07-20
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "oxivgl"
 edition = "2024"
-version = "0.6.0"
+version = "0.6.1"
 license = "MIT OR Apache-2.0"
 description = "Safe no_std Rust bindings for LVGL — embedded GUI on ESP32 and host SDL2"
 repository = "https://github.com/emobotics-dev/oxivgl"
@@ -55,7 +55,7 @@ cores3 = [
 ]
 
 [dependencies]
-oxivgl_sys = { package = "oxivgl-sys", version = "0.2.3", path = "oxivgl-sys", default-features = false }
+oxivgl_sys = { package = "oxivgl-sys", version = "0.2.4", path = "oxivgl-sys", default-features = false }
 embassy-sync = "0.8"
 embassy-time = "0.5.0"
 heapless = { version = "0.9.1", features = ["nightly"] }
@@ -75,7 +75,7 @@ exclude = ["examples/common", "oxivgl-build", "oxivgl-sys"]
 
 [dev-dependencies]
 oxivgl-examples-common = { path = "examples/common" }
-oxivgl_sys = { package = "oxivgl-sys", version = "0.2.3", path = "oxivgl-sys", default-features = false }
+oxivgl_sys = { package = "oxivgl-sys", version = "0.2.4", path = "oxivgl-sys", default-features = false }
 
 # Crates the example harness names directly on xtensa (attribute macros +
 # BSP entry points). Chip features are supplied by the active board feature

--- a/README.md
+++ b/README.md
@@ -302,8 +302,14 @@ Only widgets actually used are enabled (`LV_USE_<WIDGET> 1`) to minimize binary 
 | Feature | Effect |
 |---------|--------|
 | `esp-hal` | ESP32 tick source (`esp_hal::time`) + DMA flush pipeline |
+| `esp32` / `esp32s3` | Select the target chip across the esp-hal family (with `esp-hal`) |
 | `defmt` | `defmt` logging (embedded) |
 | `log-04` | `log` v0.4 logging (host) |
+| `png` | PNG snapshot output on host (`Snapshot::write_png`) |
+
+The examples additionally use board features `fire27` (M5Stack Fire27 / ESP32)
+and `cores3` (M5Stack CoreS3 / ESP32-S3), which select the chip across esp-hal,
+the `m5stack-core` BSP, and oxivgl's chip feature. See `examples/common`.
 
 ## Build
 
@@ -314,8 +320,8 @@ LIBCLANG_PATH=/usr/lib64 cargo +nightly check --target x86_64-unknown-linux-gnu
 # Host tests:
 LIBCLANG_PATH=/usr/lib64 cargo +nightly test --target x86_64-unknown-linux-gnu
 
-# Embedded check (requires Xtensa toolchain):
-cargo +esp -Zbuild-std=alloc,core check --features esp-hal,log-04
+# Embedded check (requires Xtensa toolchain); the chip feature selects the target:
+cargo +esp -Zbuild-std=alloc,core check --target xtensa-esp32-none-elf --features esp-hal,esp32,log-04
 ```
 
 `oxivgl-sys/build.rs` downloads and compiles LVGL from source via the `cc` crate. Expects `DEP_LV_CONFIG_PATH` pointing to `lv_conf.h`.

--- a/docs/cr-navigator-modal-background-tree-residency.md
+++ b/docs/cr-navigator-modal-background-tree-residency.md
@@ -72,7 +72,9 @@ A as the default.
   `bitmap_mask` / non-normal `blend_mode` — none used by the OSD. **0 KB to save.**
 - **Draw buffers are correctly in `.bss`** (`LVGL_BUFS`, `ui/mod.rs`), not heap.
 - **No global LVGL heap pool** (`LV_USE_STDLIB_MALLOC = CLIB`); style/image/object
-  caches already at 0 in `lv_conf.h`.
+  caches already at 0 in `lv_conf.h`. *(Config snapshot at time of writing;
+  oxivgl v0.6.0+ adds `oxivgl::mem::reserve_pool`, a runtime PSRAM heap pool, as
+  a complementary mitigation under `LV_STDLIB_BUILTIN`.)*
 - **Shadows are transient** (alloc+free within the draw call) — but the ~2 KB
   card-shadow spike *coincides with the create-time OOM instant*; cheap app-side
   mitigation is to lower `shadow_width`.

--- a/docs/memory-tuning.md
+++ b/docs/memory-tuning.md
@@ -114,6 +114,10 @@ on these targets.
    - **Dithered / multi-stop gradients** allocate; a 2-stop undithered gradient
      does not.
 
+   With a runtime PSRAM pool (`oxivgl::mem::reserve_pool`), this transient render
+   scratch is deliberately kept in **internal** DRAM — so these spikes hit the
+   internal heap even when the object tree lives in PSRAM. Budget for them there.
+
 6. **Compile out what you don't use** (`lv_conf.h`, app-owned). Disable unused
    widgets (smaller `.text`, fewer registrations). In production builds, turn
    **off** the dev-only `LV_USE_PERF_MONITOR` / `LV_USE_SYSMON` (each adds a

--- a/docs/spec-example-porting.md
+++ b/docs/spec-example-porting.md
@@ -46,7 +46,8 @@ Every example file needs:
 2. The `SPDX-License-Identifier: MIT OR Apache-2.0` header.
 3. A `//!` doc comment with a title and brief description.
 4. A single struct implementing `View`.
-5. `oxivgl_examples_common::example_main!(StructName);` at the end.
+5. `oxivgl_examples_common::example_main!(StructName::default());` at the end
+   (the macro takes a view *expression*, not a bare type name).
 
 Look at any existing example for the exact boilerplate.
 
@@ -56,26 +57,28 @@ Look at any existing example for the exact boilerplate.
 
 ### create()
 
-Builds the entire UI once. Get the active screen, create widgets, apply
-styles, return the struct. All widgets and styles that LVGL references
-must be stored in the struct to prevent drop.
+`fn create(&mut self, container: &Obj<'static>) -> Result<(), WidgetError>`.
+Builds the UI into `container` (the screen the harness supplies). Store all
+widgets and styles that LVGL references in the struct — as `Option<W>` fields,
+since the struct exists before `create` and `create` may run again — to prevent
+drop.
 
 ### update()
 
-Called every render tick. Use for polling widget values, timer-triggered
-updates, or frame-counter animations. Return `Ok(())` for static
-examples.
+`fn update(&mut self) -> Result<NavAction, WidgetError>`. Called every render
+tick. Use for polling widget values, timer-triggered updates, or frame-counter
+animations. Return `Ok(NavAction::None)` for static examples.
 
 ### on_event()
 
 Override for input-driven behavior (clicks, value changes). Use
 `event.matches(&widget, EventCode)` to dispatch. By default, events
-bubble to the active screen.
+bubble to the passed `container`.
 
-### register_events()
+### register_events_on()
 
 Override when events should be caught on intermediate containers instead
-of the screen.
+of the passed `container`.
 
 ### Extending the View trait
 
@@ -122,10 +125,9 @@ When a C example uses LVGL APIs not yet wrapped:
 5. Update the Implementation Coverage table and TOC in
    `examples/doc/README.md`.
 6. Check for regressions: `./run_tests.sh unit`.
-7. Check doc coverage:
-   ```
-   RUSTDOCFLAGS="-W missing-docs" cargo doc --no-deps
-   ```
+7. Check doc coverage: `./run_docs.sh --check` (it checks the exit status and
+   catches `error:` / build failures, which a raw `cargo doc | grep warning:`
+   silently misses).
 
 ---
 

--- a/docs/spec-memory-lifetime.md
+++ b/docs/spec-memory-lifetime.md
@@ -698,3 +698,41 @@ from `src` into `dst`. Safe (no pointer aliasing). Can be exposed directly.
 | **Could** | Expose `lv_anim_pause`, `lv_style_merge` | 12.3, 12.10 |
 | **Could** | Wrap `lv_obj_bind_style_prop` with lifetime safety | 12.4 |
 | **Won't** (single-task) | Expose `lv_lock`/`lv_unlock` | 12.7 |
+
+---
+
+## 13. Runtime Pool and Render-Scratch Allocators (v0.6.0–v0.6.1)
+
+Two oxivgl-owned allocator guards route specific LVGL allocations to
+controlled regions. Both are gated on `LV_STDLIB_BUILTIN` (the bundled
+default) and are no-ops otherwise.
+
+### 13.1 Runtime memory pool (`oxivgl::mem`, v0.6.0)
+
+`reserve_pool(region: &'static mut [MaybeUninit<u8>])` hands a
+runtime-discovered region (typically PSRAM) to LVGL's TLSF heap via
+`lv_mem_add_pool`, so the persistent object/style tree can live there.
+
+**Ownership / lifetime**: the region is `'static` and **never removed** —
+LVGL keeps allocating from it for the process lifetime, and
+`lv_mem_remove_pool` while allocations are live would corrupt the heap, so
+it is not exposed. The `&'static mut [MaybeUninit<u8>]` type encodes this,
+and the call site needs no `unsafe`. Only one pool may be registered.
+
+**Draw-buffer guard**: a registered pool makes TLSF one fungible arena, so
+LVGL's draw *buffers* (`buf_malloc`/`buf_free` in `lv_draw_buf.c`) are
+re-pointed to the Rust global allocator — internal, DMA-capable DRAM, since
+the original ESP32 cannot DMA from PSRAM. See `install_draw_buf_guard`.
+
+### 13.2 Render-scratch guard (`oxivgl::render_scratch`, v0.6.1)
+
+LVGL's transient per-frame render scratch — draw-task descriptors
+(`lv_draw_task_t`, §2) and the SW-draw mask / blur / mask-cache buffers —
+has no allocation hook. When a pool is active, a build-time source patch
+routes these through the Rust global allocator (internal DRAM), keeping the
+render hot path out of PSRAM while the tree stays in it. With no pool the
+calls delegate to LVGL's allocator unchanged. The `lv_draw_task_t` row in
+§2 is one of these rerouted allocations.
+
+Both guards flip once at driver init, before the first frame, so every
+buffer is allocated and freed under a single allocator regime.

--- a/docs/spec-navigation.md
+++ b/docs/spec-navigation.md
@@ -1,11 +1,12 @@
 # Navigation Specification
 
-**Status**: Draft
+**Status**: Implemented
 **LVGL version**: v9.5
 
 How oxivgl manages screen transitions, navigation stacks, and modal
-overlays. This spec evolves the `View` trait into a richer `View` +
-`Navigator` model that supports multi-screen applications.
+overlays. oxivgl provides a `View` + `Navigator` model for multi-screen
+applications, built on LVGL's screen and layer primitives. This document
+specifies the shipped design.
 
 ---
 
@@ -23,10 +24,10 @@ structural limitations:
 | Raw pointer handles for dynamic widgets | Error-prone, no Rust-side invalidation |
 | Poll-only `update()` | No framework-level dirty tracking |
 
-This spec evolves the `View` trait into a navigation-aware lifecycle
-and adds a `Navigator` for managing a stack of views with push/pop
-transitions and modal overlays, built on LVGL's screen and layer
-primitives (`lv_screen_load_anim`, `lv_layer_top`, `lv_obj_clean`).
+The `View` trait is a navigation-aware lifecycle, and a `Navigator`
+manages a stack of views with push/pop transitions and modal overlays,
+built on LVGL's screen and layer primitives (`lv_screen_load_anim`,
+`lv_layer_top`, `lv_obj_clean`).
 
 ---
 
@@ -59,11 +60,10 @@ overlap, the API vision spec takes precedence.
 
 ---
 
-## 3. The `View` Trait (evolved)
+## 3. The `View` Trait
 
-The `View` trait keeps its name but gains new capabilities: repeatable
-`create`, lifecycle hooks, and `NavAction` returns. Every screen of UI
-implements `View`.
+The `View` trait provides a repeatable `create`, lifecycle hooks, and
+`NavAction` returns. Every screen of UI implements `View`.
 
 ```rust
 /// A single view of UI (one screen or modal in a navigation stack).
@@ -72,15 +72,15 @@ implements `View`.
 ///
 /// 1. **Construction** — caller creates the struct (e.g. `Default::default()`)
 /// 2. [`create`] — build widgets into `container`; may be called multiple times
-/// 3. [`did_show`] — post-creation setup (optional)
-/// 4. [`update`] — per-tick polling (runs in render loop)
-/// 5. [`on_event`] — LVGL event dispatch
+/// 3. [`register_events_on`] — attach the event trampoline to `container`
+/// 4. [`did_show`] — post-creation setup (optional)
+/// 5. [`update`] / [`on_event`] — per-tick polling and LVGL event dispatch
 /// 6. [`will_hide`] — save transient state before widget teardown (optional)
 /// 7. Widget tree destroyed (navigator calls `lv_obj_clean`)
 ///
 /// Steps 2–7 repeat on each push/pop cycle for views that remain on
 /// the stack.
-pub trait View: 'static {
+pub trait View: Sized + 'static {
     /// Build all LVGL widgets for this view into `container`.
     ///
     /// Called each time this view becomes the active (topmost) view —
@@ -154,36 +154,12 @@ pub trait View: 'static {
 }
 ```
 
-### 3.1 Key Changes from Current `View`
+### 3.1 Single-View Usage
 
-| Aspect | Current `View` | Evolved `View` |
-|---|---|---|
-| Construction | `create() -> Result<Self>` | Caller constructs struct; `create(&mut self, container)` builds widgets |
-| Widget rebuilding | Not possible (create runs once) | `create` called on every push/pop return |
-| Lifecycle hooks | None | `will_hide`, `did_show` |
-| Bound | `Sized` | `'static` (must live on navigator stack) |
-| Active screen access | `lv_screen_active()` in create | `container` parameter passed by navigator |
-| `update` return | `Result<(), WidgetError>` | `Result<NavAction, WidgetError>` |
-
-### 3.2 Migration for Single-View Examples
-
-For the common case of a single-screen example, the migration is
-mechanical:
+A single-screen example implements `View` directly; the harness pushes it
+as the root:
 
 ```rust
-// Current View:
-struct MyExample { label: Label<'static> }
-impl View for MyExample {
-    fn create() -> Result<Self, WidgetError> {
-        let scr = Screen::active().unwrap();
-        let label = Label::new(&scr)?;
-        Ok(Self { label })
-    }
-    fn update(&mut self) -> Result<(), WidgetError> { Ok(()) }
-}
-example_main!(MyExample);
-
-// Evolved View:
 #[derive(Default)]
 struct MyExample { label: Option<Label<'static>> }
 impl View for MyExample {
@@ -195,9 +171,9 @@ impl View for MyExample {
 example_main!(MyExample::default());
 ```
 
-Widget fields become `Option<W>` because the struct exists before
-`create` is called. `#[derive(Default)]` eliminates manual `None`
-initialization. The `example_main!` macro accepts an expression that
+Widget fields are `Option<W>` because the struct exists before `create`
+is called, and `create` may run again after a pop. `#[derive(Default)]`
+supplies the initial `None`s. `example_main!` takes an expression that
 produces the initial view instance.
 
 ---
@@ -229,7 +205,11 @@ pub struct Navigator {
     // lv_layer_sys(). See §4.3.
     toast: Option<Box<dyn AnyView>>,
     toast_container: Option<Obj<'static>>,
-    toast_deadline: Option<Instant>,
+    // Auto-dismiss deadline in wrap-aware tick milliseconds (`get_tick_ms`),
+    // not `Instant`. See §4.3.
+    toast_deadline_ms: Option<u32>,
+    // FIFO of timed toasts waiting behind the active one (capacity 4).
+    toast_queue: VecDeque<PendingToast>,
 }
 ```
 
@@ -237,27 +217,35 @@ pub struct Navigator {
 
 ```rust
 impl Navigator {
-    /// Push a new view onto the stack.
+    /// Push the root view. Called once at startup (by `run_app_nav`); the
+    /// root gets its own created + loaded screen so pop-to-root and toast
+    /// re-parenting are uniform.
+    pub fn push_root(&mut self, view: impl View);
+
+    /// Push a new view onto the stack. Each view owns its own
+    /// `Obj<'static>` screen (via `Screen::create`), so the previous
+    /// screen's tree is destroyed *after* the new one is built.
     ///
     /// 1. Calls `will_hide()` on the current top view.
-    /// 2. Destroys the current view's widget tree (`lv_obj_clean`).
-    /// 3. Stores the current view (state preserved, widgets gone).
-    /// 4. Calls `create(container)` on the new view.
-    /// 5. Registers the event trampoline.
-    /// 6. Calls `did_show()` on the new view.
+    /// 2. Creates and loads a new screen, then calls `create(container)`
+    ///    and `register_events_on(container)` on the new view.
+    /// 3. Re-parents any active toast onto the new screen.
+    /// 4. Destroys the previous view's widget tree (`lv_obj_clean`) — its
+    ///    struct state stays on the stack.
+    /// 5. Calls `did_show()` on the new view.
     ///
     /// `anim` controls the screen transition animation. Pass `None` for
     /// an instant switch.
     pub fn push(&mut self, view: impl View, anim: Option<ScreenAnim>);
 
-    /// Pop the current view and return to the previous one.
+    /// Pop the current view and return to the previous one. The restored
+    /// view's screen is loaded and its widgets rebuilt via `create`; the
+    /// popped view's screen is cleaned up afterward.
     ///
-    /// 1. Calls `will_hide()` on the current top view.
-    /// 2. Destroys the current view's widget tree.
-    /// 3. Drops the current view entirely (removed from stack).
-    /// 4. Calls `create(container)` on the now-top view (rebuild widgets).
-    /// 5. Registers the event trampoline.
-    /// 6. Calls `did_show()` on the restored view.
+    /// 1. Loads the restored view's screen and rebuilds it (`create`,
+    ///    `register_events_on`), re-parenting any active toast onto it.
+    /// 2. Drops the popped view and destroys its widget tree.
+    /// 3. Calls `did_show()` on the restored view.
     ///
     /// Returns `Err(NavigationError::StackEmpty)` if only one view
     /// remains (the root view cannot be popped).
@@ -527,6 +515,10 @@ pub enum NavAction {
 }
 ```
 
+Convenience constructors reduce boilerplate: `NavAction::push(view)`,
+`NavAction::replace(view)`, `NavAction::modal(view)`,
+`NavAction::show_toast(view, duration)`, plus `NavAction::is_none()`.
+
 Both `update` and `on_event` return `NavAction`:
 
 ```rust
@@ -582,90 +574,53 @@ point agnostic to how data arrives. oxivgl provides `run_app`,
 `View`, and `Navigator`; the application provides the event
 infrastructure and the tasks that feed it.
 
-To reduce latency when events arrive between render ticks, `run_app`
-accepts an **async wake closure** (see §5.2) that is raced against the
-inter-tick timer, short-circuiting the sleep when the closure resolves.
+To reduce latency when events arrive between render ticks, the
+event-driven entry point `run_app_nav_keypad_events` accepts an **async
+wake closure** (see §5.2) that is raced against the inter-tick timer,
+short-circuiting the sleep when the closure resolves.
 
-### 5.2 `run_app`
+### 5.2 The `run_app` family
 
-Replaces `run_lvgl`. Initializes LVGL, creates the navigator with an
-initial screen, and runs the render loop.
+Each entry point initializes LVGL, builds the render loop, and never
+returns. There is no single universal `run_app(...wake...)`; the shape
+depends on whether the app navigates and how input arrives:
 
 ```rust
-/// Run the LVGL application with navigation support.
-///
-/// This is an embassy async task. Spawn it alongside your other
-/// application tasks. It initializes LVGL, pushes `initial` as the
-/// root screen, and loops forever: calling `update`, driving
-/// `lv_timer_handler`, and processing navigation actions.
-///
-/// `wake` is an async closure called each render tick and raced against
-/// the inter-tick timer. If `wake` resolves before the timer, `run_app`
-/// breaks out of the timer loop early and runs `update()` immediately,
-/// reducing worst-case event-to-screen latency from ~33ms to
-/// near-instant. For timer-only operation, pass
-/// `async || core::future::pending().await`.
-///
-/// Never returns.
-pub async fn run_app<const BYTES: usize, Fut: Future<Output = ()>>(
-    w: i32,
-    h: i32,
-    bufs: &'static mut LvglBuffers<BYTES>,
-    initial: impl View,
-    wake: impl Fn() -> Fut,
-) -> ! {
-    let driver = LvglDriver::init(w, h);
-    unsafe { lvgl_disp_init(w, h, bufs) };
-    DISPLAY_READY.wait().await;
+/// Single view, no navigation. Ignores NavAction (asserts it is None).
+pub async fn run_app<V: View, const BYTES: usize>(
+    w: i32, h: i32, bufs: &'static mut LvglBuffers<BYTES>, view: V) -> !;
 
-    let mut nav = Navigator::new();
-    nav.push(initial, None);
+/// Navigation entry point: creates the Navigator, pushes `initial` as
+/// the root (`push_root`), and processes NavActions each tick.
+pub async fn run_app_nav<const BYTES: usize>(
+    w: i32, h: i32, bufs: &'static mut LvglBuffers<BYTES>, initial: impl View) -> !;
 
-    const LVGL_TIMER_DELAY: u64 = LV_DEF_REFR_PERIOD as u64 / 4;
+/// Navigation + keypad input (timer-paced).
+pub async fn run_app_nav_keypad<const BYTES: usize>(
+    w: i32, h: i32, bufs: &'static mut LvglBuffers<BYTES>,
+    initial: impl View, keypad: KeypadIndev) -> !;
 
-    loop {
-        // Update active view — polls app state, returns NavAction
-        let action = nav.active_view_mut()
-            .update()
-            .unwrap_or_else(|e| { warn!("view update: {:?}", e); NavAction::None });
-
-        // Update modal if present
-        let modal_action = if let Some(modal) = nav.active_modal_mut() {
-            modal.update()
-                .unwrap_or_else(|e| { warn!("modal update: {:?}", e); NavAction::None })
-        } else {
-            NavAction::None
-        };
-
-        // Drive LVGL timers (processes widget events → on_event → NavAction)
-        for _ in 0..4 {
-            driver.timer_handler();
-
-            // Race the tick timer against the wake closure. If wake
-            // resolves first, break out early to run update() sooner.
-            let timer = Timer::after(Duration::from_millis(LVGL_TIMER_DELAY));
-            match select(timer, wake()).await {
-                Either::First(()) => {},   // normal tick
-                Either::Second(()) => break, // early wake → run update
-            }
-        }
-
-        // Process navigation: on_event actions (collected during timer_handler)
-        // take priority, then update actions.
-        nav.process_pending_event_action();
-        if !nav.has_pending() {
-            nav.process_action(action);
-        }
-        if !nav.has_pending() {
-            nav.process_action(modal_action);
-        }
-    }
-}
+/// Navigation + keypad input, event-driven: `wake` is raced against the
+/// inter-tick timer to run the loop sooner when input arrives.
+pub async fn run_app_nav_keypad_events<const BYTES: usize, Fut: Future<Output = ()>>(
+    w: i32, h: i32, bufs: &'static mut LvglBuffers<BYTES>,
+    initial: impl View, keypad: KeypadIndev, wake: impl Fn() -> Fut) -> !;
 ```
 
-The `wake` closure is called fresh each tick, producing a new future
-to race. It only needs `core::future::Future` — no dependency on any
-specific async runtime or synchronization primitive.
+All navigation variants share one inner loop (`run_app_nav_inner`):
+
+1. `update()` the active view (and the modal, if present), collecting
+   their `NavAction`s.
+2. Drive `lv_timer_handler` four times, each iteration racing the tick
+   timer against `wake()` via `embassy_time::with_timeout`, so an early
+   wake shortens the sleep. Widget events fire here, producing pending
+   `on_event` actions.
+3. `process_pending_event_action()` first — `on_event` actions win over
+   `update` actions in the same tick — then the `update` / modal actions.
+4. `drain_toast_requests()` (cross-task `post_toast`), then `tick_toast()`.
+
+The `wake` closure is called fresh each tick and only needs
+`core::future::Future` — no dependency on a specific async runtime.
 
 ### 5.3 Real Application Example
 
@@ -725,8 +680,9 @@ async fn button_task(back_pin: Input<'static>) {
 
 // Entry point — async closure wakes on signal
 #[embassy_executor::task]
-async fn ui_task(bufs: &'static mut LvglBuffers<BUF_BYTES>) -> ! {
-    run_app(320, 240, bufs, DashboardView::default(),
+async fn ui_task(bufs: &'static mut LvglBuffers<BUF_BYTES>, keypad: KeypadIndev) -> ! {
+    // The event-driven entry point is where the wake closure lives.
+    run_app_nav_keypad_events(320, 240, bufs, DashboardView::default(), keypad,
         async || WAKE.wait().await,
     ).await
 }
@@ -780,22 +736,19 @@ async || BACK_PIN.wait_for_falling_edge().await
 async || core::future::pending().await
 ```
 
-### 5.4 `example_main!` Update
+### 5.4 Harness macros
 
-The macro signature changes to accept an initial screen expression:
+The example harness (`examples/common`) provides three macros, each
+taking an expression that produces the initial view:
 
 ```rust
-// Old:
-example_main!(MyView);
-
-// New:
-example_main!(MyExample::default());
+example_main!(MyExample::default());                    // single view → run_app
+example_main_nav!(RootView::default());                // navigation → run_app_nav
+example_main_psram!(MyExample::default(), 512 * 1024);  // + runtime PSRAM pool
 ```
 
-The macro expands to
-`run_app(W, H, bufs, <expr>, async || core::future::pending().await).await`
-on embedded (timer-only, no external wake) and to the host SDL loop
-with equivalent logic.
+Each expands to the matching `run_app*` call on the selected board
+(`fire27` / `cores3`), or to the host SDL loop with equivalent logic.
 
 ---
 
@@ -807,12 +760,14 @@ stack entries. `AnyView` is an object-safe supertrait of `View`.
 ```rust
 /// Object-safe trait for type-erased views. Not implemented directly
 /// — the blanket impl covers all `View` types.
-pub trait AnyView {
+pub trait AnyView: 'static {
     fn create(&mut self, container: &Obj<'static>) -> Result<(), WidgetError>;
     fn update(&mut self) -> Result<NavAction, WidgetError>;
     fn on_event(&mut self, event: &Event) -> NavAction;
+    fn register_events_on(&mut self, container: &Obj<'static>);
     fn will_hide(&mut self);
     fn did_show(&mut self);
+    fn input_group(&self) -> Option<GroupRef>;
 }
 
 impl<T: View> AnyView for T {
@@ -883,11 +838,11 @@ observer bindings.
 | Active screen handle | `lv_screen_active()` | `Screen::active()` → `Screen` (non-owning) | Exists |
 | Top layer | `lv_layer_top()` | `Screen::layer_top()` → `Child<Obj>` | Exists |
 | Widget teardown | `lv_obj_clean()` | `Obj::clean()` | Exists |
-| New screen object | `lv_obj_create(NULL)` | `Screen::create()` → `Obj<'static>` | **Phase 1** |
-| Full-screen transition | `lv_screen_load_anim()` | `Screen::load()` | **Phase 1** |
-| Instant screen switch | `lv_screen_load()` | `Screen::load()` (with `ScreenAnimType::None`) | **Phase 1** |
-| System layer | `lv_layer_sys()` | `Screen::layer_sys()` → `Child<Obj>` | **Phase 1** |
-| Screen anim types | `lv_screen_load_anim_t` | `ScreenAnimType` enum | **Phase 1** |
+| New screen object | `lv_obj_create(NULL)` | `Screen::create()` → `Obj<'static>` | Shipped |
+| Full-screen transition | `lv_screen_load_anim()` | `Screen::load(scr, anim, auto_del)` | Shipped |
+| Instant screen switch | `lv_screen_load()` | `Screen::load_instant(scr)` | Shipped |
+| System layer | `lv_layer_sys()` | `Screen::layer_sys()` → `Child<Obj>` | Shipped |
+| Screen anim types | `lv_screen_load_anim_t` | `ScreenAnimType` enum | Shipped |
 
 `Screen` is the namespace for LVGL's screen concept. It has two roles:
 
@@ -905,64 +860,26 @@ No deprecated or experimental LVGL APIs are used.
 
 ---
 
-## 9. Migration Plan
+## 9. Implementation Status
 
-### Phase 1: Prerequisites (additive, build stays green)
-
-Add screen lifecycle wrappers to `src/widgets/screen.rs`:
-- `Screen::create() -> Obj<'static>` — wraps `lv_obj_create(NULL)`,
-  returns an owned screen object for Navigator to manage
-- `Screen::load(obj, anim)` — wraps `lv_screen_load_anim`, takes
-  any `&impl AsLvHandle`
-- `Screen::layer_sys()` — wraps `lv_layer_sys`, same pattern as
-  existing `layer_top()`
-- `ScreenAnimType` enum mirroring `lv_screen_load_anim_t`
-- `ScreenAnim` struct (type + duration + delay)
-
-### Phase 2: Core Implementation
-
-1. Evolve `View` trait in `src/view.rs` with new method signatures.
-2. Add `AnyView` trait with blanket impl.
-3. Add `Navigator` struct with push/pop/replace/modal.
-4. Add `NavAction` enum.
-5. Replace `run_lvgl` with `run_app` in `src/view.rs`.
-6. Update `example_main!` macro.
-
-### Phase 3: Validation
-
-Port one complex multi-state example to evolved `View` + `Navigator`:
-- `observer5.rs` (firmware update state machine) — currently simulates
-  multi-screen behavior with manual widget teardown and rebuilding.
-  Natural fit for push/pop.
-
-Port one simple single-screen example to verify the mechanical
-migration path works cleanly.
-
-### Phase 4: Full Migration
-
-1. Port all remaining examples to evolved `View` signatures.
-2. Remove `run_lvgl` and old `register_view_events`.
-3. Update all documentation.
-
-### Phase 5: Extend
-
-- Write a multi-screen example (e.g. menu → settings → back).
-- Write a modal example (e.g. confirmation dialog).
-- Add integration tests for push/pop/modal lifecycle.
-- Add a leak test for navigator teardown.
+Fully shipped. Reference examples: `nav1.rs` (two-screen push/pop),
+`toast_hil_demo.rs` (toasts), `menu_keypad.rs` (keypad-navigated menu).
 
 ---
 
 ## 10. Error Types
 
 ```rust
-/// Errors from navigation operations.
+/// Errors from navigation operations. Implements `Debug` and `Display`.
+#[derive(Debug)]
 pub enum NavigationError {
     /// Cannot pop the root screen.
     StackEmpty,
     /// No modal is currently active.
     NoActiveModal,
-    /// Screen creation failed.
+    /// No toast is currently active.
+    NoActiveToast,
+    /// View creation failed during a navigation transition.
     CreateFailed(WidgetError),
 }
 ```
@@ -989,27 +906,10 @@ The current spec does not define animation for modal show/dismiss.
 animations would need to use `lv_anim_*` on the backdrop/content
 objects directly.
 
-**Recommendation**: defer. Implement instant modal show/dismiss first.
-Add animation support when needed.
+**Recommendation**: modal show/dismiss is instant today; animation
+remains deferred. Full-screen transitions do animate via `ScreenAnim`.
 
-### 11.3 `NavAction` Ergonomics
-
-Returning `NavAction` from `on_event` is explicit but slightly
-inconvenient for views that never navigate. The default implementation
-returns `NavAction::None`, so non-navigating views don't need to
-override `on_event` at all. For navigating screens, a helper constructor
-pattern reduces boilerplate:
-
-```rust
-fn on_event(&mut self, event: &Event) -> NavAction {
-    if event.matches(&self.settings_btn, EventCode::CLICKED) {
-        return NavAction::push(SettingsView::default());
-    }
-    NavAction::None
-}
-```
-
-### 11.4 Background View `update`
+### 11.3 Background View `update`
 
 Only the active (topmost) full-screen view and the modal get `update`
 calls. Views lower in the stack do not receive `update` while hidden.
@@ -1037,5 +937,5 @@ channel / `watch`) for high-frequency data like sensor readings.
 | `Rc` not `Arc` | `spec-memory-lifetime.md` §4.3 | Navigator is single-task; no `Send`/`Sync` required |
 | Thin wrappers | `spec-api-vision.md` §3 | Navigator maps directly to `lv_screen_load_anim` + `lv_layer_top` |
 | `no_std` + `alloc` | `spec-api-vision.md` §4 | Uses `Vec`, `Box` from `alloc` (already a dependency) |
-| Zero warnings | `spec-rust-code.md` §2 | All types fully documented; no `#[allow()]` |
+| Zero warnings | `CLAUDE.md` (zero-warnings policy) | All types fully documented; no `#[allow()]` |
 | Hardware input via channels | §5.1, §5.3 | Button/sensor tasks send events through embassy channels; `update()` polls; no GPIO interrupts or LVGL indev required |

--- a/docs/spec-widget-wrapper.md
+++ b/docs/spec-widget-wrapper.md
@@ -85,8 +85,9 @@ invariant.
 
 ## 7. Doc Comments
 
-Every public type and method must have `///` doc comments. CI enforces
-this via `-W missing-docs`. Include a brief description of what the
+Every public type and method must have `///` doc comments. The audit is
+`./run_docs.sh --check` (it catches `error:` and build failures, not just
+`warning:`). Include a brief description of what the
 LVGL function does and any constraints (e.g. value ranges, required
 config flags).
 

--- a/examples/doc/README.md
+++ b/examples/doc/README.md
@@ -3,7 +3,9 @@
 LVGL example screens ported from the [LVGL docs](https://docs.lvgl.io/9.5/examples.html).
 
 Each example is a self-contained file with a `View` impl and a cfg-gated
-runner (`example_main!` macro selects host SDL2 or ESP32 fire27 backend).
+runner (`example_main!` / `example_main_nav!` / `example_main_psram!` macros
+select host SDL2 or an ESP32 board backend — `fire27` (ESP32) or `cores3`
+(ESP32-S3)).
 
 ## Contents
 

--- a/oxivgl-sys/Cargo.toml
+++ b/oxivgl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxivgl-sys"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Raw LVGL v9.5 FFI bindings for oxivgl — compiled from source with bindgen"

--- a/oxivgl-sys/build.rs
+++ b/oxivgl-sys/build.rs
@@ -311,6 +311,7 @@ fn main() {
         add_c_files(&mut cfg, p)
     }
     patch_btnmatrix_text_length(&lvgl_src);
+    patch_render_scratch(&lvgl_src);
     println!("cargo:SRC_DIR={}", lvgl_dir.display());
     add_c_files(&mut cfg, &lvgl_src);
     add_c_files(&mut cfg, &lv_config_dir);
@@ -535,6 +536,160 @@ fn patch_btnmatrix_text_length(lvgl_src: &Path) {
         );
         std::fs::write(&file, patched).unwrap();
     }
+}
+
+/// Route LVGL's transient per-frame render scratch to internal DRAM.
+///
+/// The SW renderer allocates a scratch buffer per draw op, every frame, and
+/// frees it in the same draw call — draw-task descriptors, scanline masks (arc,
+/// line, fill, border, triangle, rect-mask), box-shadow blur/mask buffers, and
+/// image mask/transform buffers. All use a plain `lv_malloc`/`lv_free` with no
+/// callback hook (unlike draw buffers). Once a runtime pool is registered they
+/// become eligible to land in it; when that pool is PSRAM, the churn against
+/// PSRAM-resident TLSF metadata halves render throughput on ESP32 (issue #124).
+///
+/// Redirect them to `oxivgl_render_scratch_{malloc,zalloc,free}` (defined in
+/// `oxivgl::render_scratch`), which keep the scratch in internal DRAM while a
+/// pool is active and delegate to LVGL's allocator otherwise. Those symbols are
+/// always linked, so this patch is unconditional.
+///
+/// Both the transient per-frame scratch and the radius/circle mask cache are
+/// routed. The mask cache (`lv_draw_sw_mask.c`) is read per-scanline every
+/// frame — from PSRAM it is a hot cost on ESP32 — and although it is a
+/// cross-*function* cache, every one of its alloc/free sites is lexically inside
+/// `lv_draw_sw_mask.c` (even `lv_draw_sw_mask_free_param`, which arc/line call),
+/// so exhaustive file routing keeps every pair in one regime. The gradient cache
+/// in `lv_draw_sw_grad.c` stays on LVGL's allocator: gradient-only (outside the
+/// arc/line/rounded path) and cross-function with multi-path frees, so it needs
+/// a separate, careful pass if a gradient-heavy UI ever calls for it.
+fn patch_render_scratch(lvgl_src: &Path) {
+    // The draw-task descriptor lives in lv_draw.c, which also holds non-scratch
+    // allocations (draw units, layers, sub-descriptors), so only its two
+    // descriptor sites are routed — targeted, not exhaustive.
+    route_scratch_descriptor(lvgl_src);
+
+    // These SW-draw sources allocate *only* render-internal buffers (per-frame
+    // scratch, plus the self-contained radius/circle mask cache), so every
+    // lv_malloc/lv_malloc_zeroed/lv_free is routed and the site counts are
+    // pinned: a future LVGL that adds a non-render allocation here fails the
+    // build loudly rather than silently half-routing (which would corrupt the
+    // heap). Columns: (path, n_malloc, n_malloc_zeroed, n_free).
+    for (rel, n_malloc, n_zeroed, n_free) in [
+        ("draw/sw/lv_draw_sw_arc.c", 2, 0, 2),
+        ("draw/sw/lv_draw_sw_border.c", 1, 0, 1),
+        ("draw/sw/lv_draw_sw_box_shadow.c", 6, 0, 4),
+        ("draw/sw/lv_draw_sw_fill.c", 1, 0, 1),
+        ("draw/sw/lv_draw_sw_line.c", 3, 0, 3),
+        ("draw/sw/lv_draw_sw_img.c", 5, 0, 3),
+        ("draw/sw/lv_draw_sw_mask_rect.c", 1, 0, 1),
+        ("draw/sw/lv_draw_sw_triangle.c", 1, 0, 1),
+        ("draw/sw/lv_draw_sw_mask.c", 1, 2, 5),
+    ] {
+        route_scratch_exhaustive(lvgl_src, rel, n_malloc, n_zeroed, n_free);
+    }
+}
+
+/// Prepend the render-scratch prototypes (and `<stddef.h>` for `size_t`) to a
+/// patched source. Prepending — rather than anchoring after includes — makes
+/// the declarations unconditionally visible to every routed call site, so a
+/// missing prototype can never silently degrade to an implicit `int` return
+/// that truncates the 64-bit pointer on host.
+fn with_scratch_protos(code: &str) -> String {
+    const HEAD: &str = "#include <stddef.h>\n\
+        extern void * oxivgl_render_scratch_malloc(size_t size);\n\
+        extern void * oxivgl_render_scratch_zalloc(size_t size);\n\
+        extern void oxivgl_render_scratch_free(void * ptr);\n";
+    format!("{HEAD}{code}")
+}
+
+/// Route the two draw-task descriptor sites in `lv_draw.c` (targeted: this file
+/// also holds non-scratch allocations that must stay on LVGL's allocator).
+fn route_scratch_descriptor(lvgl_src: &Path) {
+    let file = lvgl_src.join("draw/lv_draw.c");
+    if !file.exists() {
+        return;
+    }
+    let code = std::fs::read_to_string(&file).unwrap();
+    if code.contains("oxivgl_render_scratch") {
+        return; // already patched (source persists in OUT_DIR across reruns)
+    }
+    let alloc_needle = "lv_draw_task_t * new_task = lv_malloc_zeroed(LV_ALIGN_UP(sizeof(lv_draw_task_t), 8) + dsc_size);";
+    let free_needle = "lv_free(t);";
+    assert!(
+        code.contains(alloc_needle) && code.contains(free_needle),
+        "lv_draw.c descriptor sites do not match the pinned LVGL v{LVGL_VERSION} \
+         source — the render-scratch patch (issue #124) would silently no-op."
+    );
+    let code = code
+        .replace(
+            alloc_needle,
+            "lv_draw_task_t * new_task = oxivgl_render_scratch_zalloc(LV_ALIGN_UP(sizeof(lv_draw_task_t), 8) + dsc_size);",
+        )
+        .replace(free_needle, "oxivgl_render_scratch_free(t);");
+    std::fs::write(&file, with_scratch_protos(&code)).unwrap();
+}
+
+/// Route every `lv_malloc`/`lv_malloc_zeroed`/`lv_free` in an SW-draw source
+/// that allocates only render-internal buffers, pinning the site counts against
+/// version drift. Safe because every alloc/free pair is lexically in the file,
+/// so both ends are routed together (one allocation regime).
+fn route_scratch_exhaustive(
+    lvgl_src: &Path,
+    rel: &str,
+    n_malloc: usize,
+    n_zeroed: usize,
+    n_free: usize,
+) {
+    let file = lvgl_src.join(rel);
+    if !file.exists() {
+        return;
+    }
+    let code = std::fs::read_to_string(&file).unwrap();
+    if code.contains("oxivgl_render_scratch") {
+        return;
+    }
+    // Pin the shape against the verified LVGL source. `lv_malloc(` does not
+    // match inside `lv_malloc_zeroed(` (a `_` follows, not `(`), so the two
+    // counts are independent. A mismatch means the file changed — fail loudly
+    // rather than silently half-route or miss a site.
+    assert_eq!(
+        code.matches("lv_realloc(").count(), 0,
+        "{rel}: unexpected lv_realloc — re-verify scratch routing (#124)"
+    );
+    assert_eq!(
+        code.matches("lv_malloc_zeroed(").count(), n_zeroed,
+        "{rel}: lv_malloc_zeroed site count changed vs pinned LVGL v{LVGL_VERSION} — re-verify scratch routing (#124)"
+    );
+    assert_eq!(
+        code.matches("lv_malloc(").count(), n_malloc,
+        "{rel}: lv_malloc site count changed vs pinned LVGL v{LVGL_VERSION} — re-verify scratch routing (#124)"
+    );
+    assert_eq!(
+        code.matches("lv_free(").count(), n_free,
+        "{rel}: lv_free site count changed vs pinned LVGL v{LVGL_VERSION} — re-verify scratch routing (#124)"
+    );
+
+    // Replace `lv_malloc_zeroed(` before `lv_malloc(` so the plain-malloc pass
+    // never touches the zeroed sites (they are disjoint, but order makes it
+    // obviously correct).
+    let patched = code
+        .replace("lv_malloc_zeroed(", "oxivgl_render_scratch_zalloc(")
+        .replace("lv_malloc(", "oxivgl_render_scratch_malloc(")
+        .replace("lv_free(", "oxivgl_render_scratch_free(");
+    let patched = with_scratch_protos(&patched);
+    assert_eq!(
+        patched.matches("lv_malloc(").count(), 0,
+        "{rel}: unrouted lv_malloc remains after patch"
+    );
+    assert_eq!(
+        patched.matches("lv_malloc_zeroed(").count(), 0,
+        "{rel}: unrouted lv_malloc_zeroed remains after patch"
+    );
+    assert_eq!(
+        patched.matches("lv_free(").count(), 0,
+        "{rel}: unrouted lv_free remains after patch"
+    );
+    std::fs::write(&file, patched).unwrap();
 }
 
 fn add_c_files(build: &mut cc::Build, path: impl AsRef<Path>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,12 @@ pub mod diag;
 #[cfg(lvgl_builtin_malloc)]
 pub mod mem;
 
+// Internal: keeps LVGL's transient per-frame render scratch (draw-task
+// descriptors + SW draw masks/buffers) in internal DRAM via symbols the
+// `oxivgl-sys` build-time patch of the SW draw sources calls by name. Always
+// compiled so those symbols exist under every allocator backend.
+mod render_scratch;
+
 /// Declare an LVGL image asset compiled by `oxivgl-build`.
 ///
 /// Equivalent to LVGL's `LV_IMAGE_DECLARE`. Generates a safe

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -229,8 +229,10 @@ pub(crate) fn apply_pending() {
     );
 
     // The pool is now part of the same TLSF heap as everything else, so LVGL's
-    // draw buffers could be served from it. They must not be — keep them out.
+    // draw buffers and per-frame draw-task descriptors could be served from it.
+    // They must not be — keep the whole render hot path out of the pool.
     install_draw_buf_guard();
+    crate::render_scratch::activate();
 
     APPLIED.store(true, Ordering::Release);
 }

--- a/src/render_scratch.rs
+++ b/src/render_scratch.rs
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Keep LVGL's transient per-frame render scratch in internal DRAM.
+//!
+//! The software renderer allocates a scratch buffer *per draw op, every frame*,
+//! and frees it within the same draw call — draw-task descriptors
+//! (`lv_draw_add_task`), scanline masks (arc, line, fill, border, triangle,
+//! rect-mask), the box-shadow blur/mask buffers, and image mask/transform
+//! buffers. All go through a plain `lv_malloc` / `lv_free` with **no callback
+//! hook** — unlike draw *buffers*, which expose `buf_malloc_cb` and are
+//! redirected by [`crate::mem`]'s buffer guard.
+//!
+//! Once a runtime pool is registered (see [`crate::mem::reserve_pool`]) LVGL's
+//! TLSF heap is one fungible arena, so this scratch becomes eligible to land in
+//! the pool. When that pool is PSRAM it is expensive: serving per-frame
+//! alloc/free churn against PSRAM-resident TLSF metadata halves render
+//! throughput on the original ESP32 (issue #124). It must stay in internal DRAM,
+//! exactly like the pixel draw buffers — so render cost tracks dirty-region
+//! complexity, not total UI size.
+//!
+//! The only clean seam is the allocation site, so `oxivgl-sys` patches the SW
+//! draw sources at build time to route these calls through the three symbols
+//! defined here. While the guard is [`active`](activate) the scratch comes from
+//! the Rust global allocator — internal, DMA-capable DRAM by construction (a BSP
+//! that hands out a private PSRAM region consumes the peripheral, so the same
+//! PSRAM cannot also back the global heap). Otherwise — under `LV_STDLIB_CLIB`,
+//! or `LV_STDLIB_BUILTIN` with no pool registered — the calls delegate straight
+//! to LVGL's allocator, so behaviour is byte-for-byte unchanged.
+//!
+//! Only *transient* per-frame scratch is routed. LVGL's gradient and
+//! circle-mask *caches* — allocated once and read across frames, and freed
+//! cross-function — are intentionally left on LVGL's allocator: they are not the
+//! per-frame churn this targets, and their alloc/free pairing does not fit the
+//! single-regime invariant below.
+
+use core::ffi::c_void;
+use core::sync::atomic::{AtomicBool, Ordering};
+
+/// Bytes reserved ahead of each block to record its allocation size. The free
+/// callback receives only a pointer, but Rust's deallocator needs the original
+/// size, so it is stashed immediately before the returned pointer — the same
+/// technique the draw-buffer guard uses in [`crate::mem`].
+const SIZE_HEADER: usize = core::mem::size_of::<usize>();
+
+/// Alignment of a returned block. LVGL uses the pointer as-is (it does not
+/// re-align this scratch afterward), so this must satisfy the largest scratch
+/// type's alignment directly. `usize` alignment (4 on the 32-bit targets, 8 on
+/// host) covers it: no routed scratch carries a member wider than a pointer on
+/// 32-bit. Matches `draw_buf_malloc`.
+const ALIGN: usize = core::mem::align_of::<usize>();
+
+/// Set once, before the first frame, when a runtime pool is registered.
+///
+/// Until then — and always under CLIB or when no pool is registered — the
+/// callbacks delegate to LVGL's allocator. Because the flip happens before any
+/// rendering (in [`crate::mem::apply_pending`], driver-init time), every scratch
+/// block is allocated and freed under one regime, so the free callback can trust
+/// this flag without tagging individual allocations.
+static GUARD_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+/// Activate render-scratch rerouting.
+///
+/// Called from driver init when a pool has been registered — the same trigger,
+/// and the same pre-render moment, as the draw-buffer guard.
+#[cfg(lvgl_builtin_malloc)]
+pub(crate) fn activate() {
+    GUARD_ACTIVE.store(true, Ordering::Release);
+}
+
+/// Allocate `size` bytes from the Rust global allocator with a size header for
+/// [`free_internal`]. `zeroed` mirrors `lv_malloc` vs `lv_malloc_zeroed`.
+/// Returns NULL on overflow or allocation failure, as LVGL expects.
+fn alloc_internal(size: usize, zeroed: bool) -> *mut c_void {
+    let Some(total) = size.checked_add(SIZE_HEADER) else {
+        return core::ptr::null_mut();
+    };
+    let Ok(layout) = alloc::alloc::Layout::from_size_align(total, ALIGN) else {
+        return core::ptr::null_mut();
+    };
+    // SAFETY: `total >= SIZE_HEADER > 0`, so the layout has non-zero size.
+    let base = unsafe {
+        if zeroed {
+            alloc::alloc::alloc_zeroed(layout)
+        } else {
+            alloc::alloc::alloc(layout)
+        }
+    };
+    if base.is_null() {
+        return core::ptr::null_mut();
+    }
+    // SAFETY: `base` is a fresh, `usize`-aligned allocation of at least
+    // `SIZE_HEADER` bytes. Writing the header never touches the user region, so
+    // the `zeroed` guarantee above is preserved.
+    unsafe {
+        base.cast::<usize>().write(total);
+        base.add(SIZE_HEADER).cast()
+    }
+}
+
+/// Free a non-null pointer returned by [`alloc_internal`].
+///
+/// # Safety
+/// `ptr` must be a pointer returned by [`alloc_internal`] and not yet freed.
+unsafe fn free_internal(ptr: *mut c_void) {
+    // SAFETY: the header sits `SIZE_HEADER` bytes below the returned pointer and
+    // records the total size passed to the allocator.
+    unsafe {
+        let base = ptr.cast::<u8>().sub(SIZE_HEADER);
+        let total = base.cast::<usize>().read();
+        let layout = alloc::alloc::Layout::from_size_align_unchecked(total, ALIGN);
+        alloc::alloc::dealloc(base, layout);
+    }
+}
+
+/// Allocate uninitialised render scratch. Replaces `lv_malloc` at the routed SW
+/// draw sites via the build-time patch in `oxivgl-sys`.
+///
+/// # Safety
+/// Exported for the patched C call sites; not intended to be called from Rust.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn oxivgl_render_scratch_malloc(size: usize) -> *mut c_void {
+    if GUARD_ACTIVE.load(Ordering::Acquire) {
+        alloc_internal(size, false)
+    } else {
+        // SAFETY: valid at any point after `lv_init`, on the single LVGL task.
+        unsafe { oxivgl_sys::lv_malloc(size) }
+    }
+}
+
+/// Allocate zeroed render scratch. Replaces `lv_malloc_zeroed` (the draw-task
+/// descriptor site) via the build-time patch in `oxivgl-sys`.
+///
+/// # Safety
+/// Exported for the patched C call sites; not intended to be called from Rust.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn oxivgl_render_scratch_zalloc(size: usize) -> *mut c_void {
+    if GUARD_ACTIVE.load(Ordering::Acquire) {
+        alloc_internal(size, true)
+    } else {
+        // SAFETY: valid at any point after `lv_init`, on the single LVGL task.
+        unsafe { oxivgl_sys::lv_malloc_zeroed(size) }
+    }
+}
+
+/// Free render scratch. Replaces `lv_free` at the routed SW draw sites.
+///
+/// The guard flag does not change between a block's allocation and its free (it
+/// flips once, before rendering), so the same branch is taken as at allocation.
+///
+/// # Safety
+/// `ptr` must be NULL or a pointer previously returned by
+/// [`oxivgl_render_scratch_malloc`] / [`oxivgl_render_scratch_zalloc`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn oxivgl_render_scratch_free(ptr: *mut c_void) {
+    if ptr.is_null() {
+        return;
+    }
+    if GUARD_ACTIVE.load(Ordering::Acquire) {
+        // SAFETY: allocated by the active branch of a routed allocator.
+        unsafe { free_internal(ptr) }
+    } else {
+        // SAFETY: allocated by LVGL, on the single LVGL task.
+        unsafe { oxivgl_sys::lv_free(ptr) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A zeroed block round-trips through the size header: the region is zeroed,
+    /// writable, and freed with the size the header preserved (an incorrect size
+    /// would trip the allocator under Miri/ASan).
+    #[test]
+    fn zalloc_zeroes_and_round_trips_through_the_size_header() {
+        const SIZE: usize = 96;
+        let p = alloc_internal(SIZE, true).cast::<u8>();
+        assert!(!p.is_null());
+        // SAFETY: `SIZE` bytes were requested and zeroed.
+        unsafe {
+            for i in 0..SIZE {
+                assert_eq!(*p.add(i), 0, "byte {i} not zeroed");
+                *p.add(i) = 0xAB;
+            }
+            free_internal(p.cast());
+        }
+    }
+
+    /// A non-zeroed block round-trips through the header too (no zeroing
+    /// guarantee, but the size must survive the alloc/free cycle).
+    #[test]
+    fn malloc_round_trips_through_the_size_header() {
+        const SIZE: usize = 64;
+        let p = alloc_internal(SIZE, false).cast::<u8>();
+        assert!(!p.is_null());
+        // SAFETY: `SIZE` bytes were requested; write then free.
+        unsafe {
+            for i in 0..SIZE {
+                *p.add(i) = 0xCD;
+            }
+            free_internal(p.cast());
+        }
+    }
+
+    /// A size that would overflow the header addition returns NULL rather than
+    /// wrapping — matching an LVGL allocation failure.
+    #[test]
+    fn alloc_returns_null_rather_than_overflowing() {
+        assert!(alloc_internal(usize::MAX, false).is_null());
+        assert!(alloc_internal(usize::MAX, true).is_null());
+    }
+}

--- a/src/render_scratch.rs
+++ b/src/render_scratch.rs
@@ -26,11 +26,12 @@
 //! or `LV_STDLIB_BUILTIN` with no pool registered — the calls delegate straight
 //! to LVGL's allocator, so behaviour is byte-for-byte unchanged.
 //!
-//! Only *transient* per-frame scratch is routed. LVGL's gradient and
-//! circle-mask *caches* — allocated once and read across frames, and freed
-//! cross-function — are intentionally left on LVGL's allocator: they are not the
-//! per-frame churn this targets, and their alloc/free pairing does not fit the
-//! single-regime invariant below.
+//! Both the transient per-frame scratch and the radius/circle mask cache
+//! (`lv_draw_sw_mask.c`, read per-scanline every frame by arc, rounded-rect,
+//! border and shadow draws) are routed — the mask cache is safe to route because
+//! all of its alloc/free sites are lexically inside that one file, so both ends
+//! move together. LVGL's gradient cache (`lv_draw_sw_grad.c`) is left on LVGL's
+//! allocator: gradient-only and cross-function with multi-path frees.
 
 use core::ffi::c_void;
 use core::sync::atomic::{AtomicBool, Ordering};

--- a/tests/mem_pool.rs
+++ b/tests/mem_pool.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 //! Verifies that a reserved runtime pool actually reaches LVGL's heap, and that
-//! draw buffers are kept out of it.
+//! the render hot path — draw buffers and per-frame draw-task descriptors — is
+//! kept out of it.
 //!
 //! This is a separate test binary on purpose: `LvglDriver::init()` may run only
 //! once per process, and the pool has to be reserved *before* it. A single test
@@ -20,7 +21,7 @@ use oxivgl::mem::{self, MemError};
 const POOL_SIZE: usize = 128 * 1024;
 
 #[test]
-fn reserved_pool_reaches_lvgl_and_excludes_draw_buffers() {
+fn reserved_pool_reaches_lvgl_and_excludes_draw_buffers_and_tasks() {
     // A leaked heap allocation is genuinely `'static`, which is what the pool
     // contract requires — LVGL never releases a pool.
     let pool: &'static mut [MaybeUninit<u8>] =
@@ -87,6 +88,68 @@ fn reserved_pool_reaches_lvgl_and_excludes_draw_buffers() {
         // SAFETY: created directly above and not referenced elsewhere.
         unsafe { oxivgl_sys::lv_draw_buf_destroy(buf) };
     }
+
+    // ── Render-transient scratch stays out of the pool ────────────────────
+    // Same hazard as draw buffers, but LVGL allocates per-frame render scratch
+    // (draw-task descriptors via `lv_malloc_zeroed`, SW draw masks via plain
+    // `lv_malloc`) with no callback hook. The build-time patch routes these
+    // through `oxivgl_render_scratch_{zalloc,malloc,free}`, which — while the
+    // pool guard is active — serve from the Rust global allocator (internal
+    // DRAM). A block must therefore fall outside the pool and, while alive,
+    // leave LVGL's own heap untouched (issue #124).
+    unsafe extern "C" {
+        fn oxivgl_render_scratch_malloc(size: usize) -> *mut core::ffi::c_void;
+        fn oxivgl_render_scratch_zalloc(size: usize) -> *mut core::ffi::c_void;
+        fn oxivgl_render_scratch_free(ptr: *mut core::ffi::c_void);
+    }
+    // Representative of a descriptor / mask buffer; routing is size-independent.
+    const SCRATCH_SIZE: usize = 256;
+
+    let used = || -> usize {
+        let mut mon = unsafe { core::mem::zeroed::<oxivgl_sys::lv_mem_monitor_t>() };
+        unsafe { oxivgl_sys::lv_mem_monitor(&mut mon) };
+        mon.total_size - mon.free_size
+    };
+
+    // Both the zeroed (descriptor) and non-zeroed (SW-mask) variants must route.
+    type ScratchAlloc = unsafe extern "C" fn(usize) -> *mut core::ffi::c_void;
+    for (name, alloc) in [
+        ("zalloc", oxivgl_render_scratch_zalloc as ScratchAlloc),
+        ("malloc", oxivgl_render_scratch_malloc as ScratchAlloc),
+    ] {
+        let used_before = used();
+        let block = unsafe { alloc(SCRATCH_SIZE) };
+        assert!(!block.is_null(), "render-scratch {name} allocation failed");
+        let addr = block as usize;
+        assert!(
+            addr < pool_start || addr >= pool_end,
+            "render-scratch {name} landed inside the runtime pool at {addr:#x} \
+             (pool {pool_start:#x}..{pool_end:#x}) — per-frame scratch would \
+             thrash PSRAM-resident TLSF metadata (issue #124)"
+        );
+        // While the block is still alive, LVGL's heap must be untouched: it came
+        // from the Rust global allocator, not the pool or the primary heap.
+        assert_eq!(
+            used(), used_before,
+            "render-scratch {name} consumed {} bytes of LVGL's heap — the guard \
+             did not route it to internal DRAM",
+            used().wrapping_sub(used_before),
+        );
+        unsafe { oxivgl_render_scratch_free(block) };
+    }
+
+    // Sensitivity control: the `lv_malloc` the patch replaced *does* draw from
+    // LVGL's heap, so the equalities above are real checks, not trivially-zero
+    // deltas.
+    let used_before = used();
+    let control = unsafe { oxivgl_sys::lv_malloc(SCRATCH_SIZE) };
+    assert!(!control.is_null(), "control lv_malloc failed");
+    assert!(
+        used() > used_before,
+        "lv_malloc did not grow LVGL's heap — the used-bytes metric is \
+         insensitive, so the routing assertions prove nothing"
+    );
+    unsafe { oxivgl_sys::lv_free(control) };
 
     // ── Reserving after init is refused ───────────────────────────────────
     let err = unsafe { mem::reserve_pool_raw(spare.as_mut_ptr().cast(), spare.len()) }


### PR DESCRIPTION
Fixes #124. Fixes #123. Root cause of downstream perf regression emobotics-dev/alternator-regulator#137.

This is the v0.6.1 release PR: the render-scratch fix, a navigation-spec reconciliation, a docs staleness sweep, and the release prep (notes + changelog). Commit order: fix → version bump → docs(#123) → docs sweep → release prep.

---

## fix(mem): render-transient scratch stays internal (#124)

**Problem.** The 0.6.0 PSRAM pool support kept LVGL's pixel draw buffers out of the pool, but the SW renderer allocates a scratch buffer **per draw op, every frame** — draw-task descriptors, scanline masks (arc, line, fill, border, triangle, rect-mask), box-shadow blur/mask buffers, image mask/transform buffers, and the radius/circle mask cache — through a plain `lv_malloc`/`lv_free` with no callback hook. Once a runtime pool is registered, TLSF is one fungible arena, so this scratch lands in PSRAM. On ESP32 (slow, uncached SPI PSRAM) that **halved** the meter render.

**Fix.** `oxivgl-sys` patches the SW draw sources at build time to route these through `oxivgl_render_scratch_{malloc,zalloc,free}` (in `oxivgl::render_scratch`): internal DRAM while a pool is active, delegate-unchanged otherwise. Nine SW files routed exhaustively with pinned site counts (a future LVGL adding a non-render alloc there fails the build); gradient cache left on LVGL's allocator (cross-function, gradient-only).

**Measured (rig HIL, meter FPS):** Fire27 `16 → 7 (bug) → 15 (fix)`; CoreS3 `15 → 21`, CPU `38% → 28%`. Soak 20/20 both boards, full HIL 14/14, no regression. Downstream #137 closed as resolved.

## docs: navigation spec reconciled with shipped API (#123)

`docs/spec-navigation.md` was a Draft implementation *plan* for a shipped feature. Turned it into a spec of what exists (1041 → 941 lines): removed the migration table/guide and §9 Migration Plan (Phases 1–5); Status Draft → Implemented; corrected the `run_app` family, lifecycle order, toast internals (`toast_deadline_ms`/`toast_queue`), `AnyView` methods, `NavigationError::NoActiveToast`, `push_root`, `Screen::load_instant`, the `example_main!`/`_nav!`/`_psram!` split, and the §8 "Phase 1" statuses.

## docs: staleness sweep

Audited the doc set against shipped v0.6.x code:
- `render_scratch.rs` module doc corrected (circle-mask cache is now routed, not deferred).
- README: fixed embedded check command (missing chip/target); Features table (`esp32`/`esp32s3`/`png`/`fire27`/`cores3`).
- spec-example-porting / spec-widget-wrapper: `example_main!` expression form, pre-nav `View` API in §4, doc-check → `./run_docs.sh --check`.
- spec-memory-lifetime: new §13 on the `mem`/`render_scratch` allocator guards.
- memory-tuning / examples-doc / cr-navigator: render-scratch stays internal under a pool; `cores3` + runtime PSRAM pool notes.

## Verification
- Host: `run_tests.sh all` green (pool test asserts both scratch variants route + caches untouched; 535 integration tests exercise the patched SW path); `run_docs.sh --check` clean; zero warnings.
- On-target: Fire27 + CoreS3 HIL (above), both boards' CI builds green.

## Release
`oxivgl-sys 0.2.3 → 0.2.4`, `oxivgl 0.6.0 → 0.6.1`. GitHub Release body will come from the CHANGELOG `[0.6.1]` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
