### PR TITLE
docs: Reconcile navigation spec (#123) + staleness sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.6.1] — Unreleased
+## [0.6.1] — 2026-07-21
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -302,8 +302,14 @@ Only widgets actually used are enabled (`LV_USE_<WIDGET> 1`) to minimize binary 
 | Feature | Effect |
 |---------|--------|
 | `esp-hal` | ESP32 tick source (`esp_hal::time`) + DMA flush pipeline |
+| `esp32` / `esp32s3` | Select the target chip across the esp-hal family (with `esp-hal`) |
 | `defmt` | `defmt` logging (embedded) |
 | `log-04` | `log` v0.4 logging (host) |
+| `png` | PNG snapshot output on host (`Snapshot::write_png`) |
+
+The examples additionally use board features `fire27` (M5Stack Fire27 / ESP32)
+and `cores3` (M5Stack CoreS3 / ESP32-S3), which select the chip across esp-hal,
+the `m5stack-core` BSP, and oxivgl's chip feature. See `examples/common`.
 
 ## Build
 
@@ -314,8 +320,8 @@ LIBCLANG_PATH=/usr/lib64 cargo +nightly check --target x86_64-unknown-linux-gnu
 # Host tests:
 LIBCLANG_PATH=/usr/lib64 cargo +nightly test --target x86_64-unknown-linux-gnu
 
-# Embedded check (requires Xtensa toolchain):
-cargo +esp -Zbuild-std=alloc,core check --features esp-hal,log-04
+# Embedded check (requires Xtensa toolchain); the chip feature selects the target:
+cargo +esp -Zbuild-std=alloc,core check --target xtensa-esp32-none-elf --features esp-hal,esp32,log-04
 ```
 
 `oxivgl-sys/build.rs` downloads and compiles LVGL from source via the `cc` crate. Expects `DEP_LV_CONFIG_PATH` pointing to `lv_conf.h`.

--- a/RELEASE_NOTES_v0.6.1.md
+++ b/RELEASE_NOTES_v0.6.1.md
@@ -1,0 +1,86 @@
+# oxivgl v0.6.1
+
+A single, targeted fix: **LVGL's transient per-frame render scratch no longer
+leaks into a runtime PSRAM pool**. This is what made a heavy screen *slower* on
+the original ESP32 after moving LVGL's heap to PSRAM — the exact regression the
+0.6.0 pool support could trigger. With it, the render hot path stays in internal
+DRAM while the persistent widget tree lives in PSRAM, so both boards keep their
+best render rate *with* the heap in PSRAM.
+
+## The fix — render scratch stays internal (#124)
+
+`oxivgl::mem::reserve_pool` (0.6.0) already kept LVGL's **pixel draw buffers**
+out of a PSRAM pool, via the callback hooks LVGL exposes for them
+(`buf_malloc_cb`/`buf_free_cb`). But LVGL allocates a second, larger class of
+short-lived render memory with **no such hook** — a plain `lv_malloc`/`lv_free`
+per draw op, every frame:
+
+- **draw-task descriptors** (`lv_draw_add_task`),
+- **SW scanline masks** — arc, line, fill, border, triangle, rect-mask,
+- **box-shadow** blur/mask buffers,
+- **image** mask/transform buffers,
+- the **radius/circle mask cache** read per-scanline by arc, rounded-rect,
+  border and shadow draws.
+
+Once a runtime pool is registered, LVGL's TLSF heap is one fungible arena, so all
+of this becomes eligible to land in the pool. When that pool is PSRAM the cost is
+real: the original ESP32 (LX6) reads its SPI PSRAM slowly with no effective
+cache, so serving per-frame allocation churn — and per-scanline mask reads — from
+PSRAM-resident memory **halved a heavy meter screen's render rate**.
+
+`oxivgl-sys` now patches the SW draw sources at build time to route these
+allocations through `oxivgl_render_scratch_{malloc,zalloc,free}`
+(`oxivgl::render_scratch`):
+
+- **While a pool is active** they serve from the Rust global allocator —
+  internal, DMA-capable DRAM by construction (a BSP that hands out a private
+  PSRAM region consumes the peripheral, so the same PSRAM cannot also back the
+  global heap). The direct analogue of the existing draw-buffer guard, extended
+  from pixel buffers to *all* transient render scratch.
+- **With no pool registered, or under `LV_STDLIB_CLIB`**, they delegate straight
+  to LVGL's allocator — behaviour is byte-for-byte unchanged.
+
+The guard flips once during driver init, before the first frame, so every block
+is allocated and freed under one allocator regime. Nine SW files are routed
+*exhaustively* with **pinned site counts**: a future LVGL that adds a non-render
+allocation to one of them fails the build rather than silently half-routing a
+buffer (which would corrupt the heap). This is safe because every alloc/free pair
+is lexically inside its own file — including the mask cache's, whose frees live
+in `lv_draw_sw_mask_free_param`/`_cleanup` that arc and line call across function
+boundaries. LVGL's gradient cache (`lv_draw_sw_grad.c`) is intentionally left on
+LVGL's allocator: it is gradient-only and cross-*function-and-path*, so it needs
+a separate, careful pass if a gradient-heavy UI ever calls for it.
+
+Net: render cost tracks **dirty-region complexity, not total UI size** — the
+point of putting a large widget tree in PSRAM.
+
+## Measured on hardware
+
+Meter screen (arc + tick scale + glow + labels), `perf_test` on the rig, FPS:
+
+| target | before PSRAM | PSRAM (0.6.0) | **0.6.1** |
+|---|---:|---:|---:|
+| **ESP32 (Fire27)** meter | 16 | **7** (7–15) | **15** |
+| ESP32-S3 (CoreS3) meter | 15 | 20 | **21** |
+
+CoreS3 CPU on the meter dropped **38% → 28%** with the pool and stays there. The
+remaining Fire27 15-vs-16 gap is the widget-tree *read* from PSRAM — inherent to
+keeping the tree there, and marginal. Soak and full HIL suites pass on both
+boards with no stability or perf regression from the changed allocation path.
+
+## Upgrade notes
+
+- **No API changes.** `reserve_pool` and everything else in `oxivgl::mem` are
+  unchanged. If you register a PSRAM pool, you simply stop paying the render
+  penalty — no code change required.
+- **`oxivgl 0.6.1` requires `oxivgl-sys 0.2.4`** (the SW-draw source patches live
+  in the sys crate). A plain `cargo update` picks both up.
+- Applications on 0.6.0 that sized `LV_MEM_SIZE` large enough to keep the render
+  working set in the internal primary heap as a workaround no longer need that
+  band-aid.
+
+## Fixed
+
+- **Transient per-frame render scratch leaked into a registered PSRAM pool**
+  (#124), halving a heavy screen's render rate on ESP32. Routed to internal DRAM;
+  see above.

--- a/docs/cr-navigator-modal-background-tree-residency.md
+++ b/docs/cr-navigator-modal-background-tree-residency.md
@@ -72,7 +72,9 @@ A as the default.
   `bitmap_mask` / non-normal `blend_mode` — none used by the OSD. **0 KB to save.**
 - **Draw buffers are correctly in `.bss`** (`LVGL_BUFS`, `ui/mod.rs`), not heap.
 - **No global LVGL heap pool** (`LV_USE_STDLIB_MALLOC = CLIB`); style/image/object
-  caches already at 0 in `lv_conf.h`.
+  caches already at 0 in `lv_conf.h`. *(Config snapshot at time of writing;
+  oxivgl v0.6.0+ adds `oxivgl::mem::reserve_pool`, a runtime PSRAM heap pool, as
+  a complementary mitigation under `LV_STDLIB_BUILTIN`.)*
 - **Shadows are transient** (alloc+free within the draw call) — but the ~2 KB
   card-shadow spike *coincides with the create-time OOM instant*; cheap app-side
   mitigation is to lower `shadow_width`.

--- a/docs/memory-tuning.md
+++ b/docs/memory-tuning.md
@@ -114,6 +114,10 @@ on these targets.
    - **Dithered / multi-stop gradients** allocate; a 2-stop undithered gradient
      does not.
 
+   With a runtime PSRAM pool (`oxivgl::mem::reserve_pool`), this transient render
+   scratch is deliberately kept in **internal** DRAM — so these spikes hit the
+   internal heap even when the object tree lives in PSRAM. Budget for them there.
+
 6. **Compile out what you don't use** (`lv_conf.h`, app-owned). Disable unused
    widgets (smaller `.text`, fewer registrations). In production builds, turn
    **off** the dev-only `LV_USE_PERF_MONITOR` / `LV_USE_SYSMON` (each adds a

--- a/docs/spec-example-porting.md
+++ b/docs/spec-example-porting.md
@@ -46,7 +46,8 @@ Every example file needs:
 2. The `SPDX-License-Identifier: MIT OR Apache-2.0` header.
 3. A `//!` doc comment with a title and brief description.
 4. A single struct implementing `View`.
-5. `oxivgl_examples_common::example_main!(StructName);` at the end.
+5. `oxivgl_examples_common::example_main!(StructName::default());` at the end
+   (the macro takes a view *expression*, not a bare type name).
 
 Look at any existing example for the exact boilerplate.
 
@@ -56,26 +57,28 @@ Look at any existing example for the exact boilerplate.
 
 ### create()
 
-Builds the entire UI once. Get the active screen, create widgets, apply
-styles, return the struct. All widgets and styles that LVGL references
-must be stored in the struct to prevent drop.
+`fn create(&mut self, container: &Obj<'static>) -> Result<(), WidgetError>`.
+Builds the UI into `container` (the screen the harness supplies). Store all
+widgets and styles that LVGL references in the struct — as `Option<W>` fields,
+since the struct exists before `create` and `create` may run again — to prevent
+drop.
 
 ### update()
 
-Called every render tick. Use for polling widget values, timer-triggered
-updates, or frame-counter animations. Return `Ok(())` for static
-examples.
+`fn update(&mut self) -> Result<NavAction, WidgetError>`. Called every render
+tick. Use for polling widget values, timer-triggered updates, or frame-counter
+animations. Return `Ok(NavAction::None)` for static examples.
 
 ### on_event()
 
 Override for input-driven behavior (clicks, value changes). Use
 `event.matches(&widget, EventCode)` to dispatch. By default, events
-bubble to the active screen.
+bubble to the passed `container`.
 
-### register_events()
+### register_events_on()
 
 Override when events should be caught on intermediate containers instead
-of the screen.
+of the passed `container`.
 
 ### Extending the View trait
 
@@ -122,10 +125,9 @@ When a C example uses LVGL APIs not yet wrapped:
 5. Update the Implementation Coverage table and TOC in
    `examples/doc/README.md`.
 6. Check for regressions: `./run_tests.sh unit`.
-7. Check doc coverage:
-   ```
-   RUSTDOCFLAGS="-W missing-docs" cargo doc --no-deps
-   ```
+7. Check doc coverage: `./run_docs.sh --check` (it checks the exit status and
+   catches `error:` / build failures, which a raw `cargo doc | grep warning:`
+   silently misses).
 
 ---
 

--- a/docs/spec-memory-lifetime.md
+++ b/docs/spec-memory-lifetime.md
@@ -698,3 +698,41 @@ from `src` into `dst`. Safe (no pointer aliasing). Can be exposed directly.
 | **Could** | Expose `lv_anim_pause`, `lv_style_merge` | 12.3, 12.10 |
 | **Could** | Wrap `lv_obj_bind_style_prop` with lifetime safety | 12.4 |
 | **Won't** (single-task) | Expose `lv_lock`/`lv_unlock` | 12.7 |
+
+---
+
+## 13. Runtime Pool and Render-Scratch Allocators (v0.6.0–v0.6.1)
+
+Two oxivgl-owned allocator guards route specific LVGL allocations to
+controlled regions. Both are gated on `LV_STDLIB_BUILTIN` (the bundled
+default) and are no-ops otherwise.
+
+### 13.1 Runtime memory pool (`oxivgl::mem`, v0.6.0)
+
+`reserve_pool(region: &'static mut [MaybeUninit<u8>])` hands a
+runtime-discovered region (typically PSRAM) to LVGL's TLSF heap via
+`lv_mem_add_pool`, so the persistent object/style tree can live there.
+
+**Ownership / lifetime**: the region is `'static` and **never removed** —
+LVGL keeps allocating from it for the process lifetime, and
+`lv_mem_remove_pool` while allocations are live would corrupt the heap, so
+it is not exposed. The `&'static mut [MaybeUninit<u8>]` type encodes this,
+and the call site needs no `unsafe`. Only one pool may be registered.
+
+**Draw-buffer guard**: a registered pool makes TLSF one fungible arena, so
+LVGL's draw *buffers* (`buf_malloc`/`buf_free` in `lv_draw_buf.c`) are
+re-pointed to the Rust global allocator — internal, DMA-capable DRAM, since
+the original ESP32 cannot DMA from PSRAM. See `install_draw_buf_guard`.
+
+### 13.2 Render-scratch guard (`oxivgl::render_scratch`, v0.6.1)
+
+LVGL's transient per-frame render scratch — draw-task descriptors
+(`lv_draw_task_t`, §2) and the SW-draw mask / blur / mask-cache buffers —
+has no allocation hook. When a pool is active, a build-time source patch
+routes these through the Rust global allocator (internal DRAM), keeping the
+render hot path out of PSRAM while the tree stays in it. With no pool the
+calls delegate to LVGL's allocator unchanged. The `lv_draw_task_t` row in
+§2 is one of these rerouted allocations.
+
+Both guards flip once at driver init, before the first frame, so every
+buffer is allocated and freed under a single allocator regime.

--- a/docs/spec-navigation.md
+++ b/docs/spec-navigation.md
@@ -1,11 +1,12 @@
 # Navigation Specification
 
-**Status**: Draft
+**Status**: Implemented
 **LVGL version**: v9.5
 
 How oxivgl manages screen transitions, navigation stacks, and modal
-overlays. This spec evolves the `View` trait into a richer `View` +
-`Navigator` model that supports multi-screen applications.
+overlays. oxivgl provides a `View` + `Navigator` model for multi-screen
+applications, built on LVGL's screen and layer primitives. This document
+specifies the shipped design.
 
 ---
 
@@ -23,10 +24,10 @@ structural limitations:
 | Raw pointer handles for dynamic widgets | Error-prone, no Rust-side invalidation |
 | Poll-only `update()` | No framework-level dirty tracking |
 
-This spec evolves the `View` trait into a navigation-aware lifecycle
-and adds a `Navigator` for managing a stack of views with push/pop
-transitions and modal overlays, built on LVGL's screen and layer
-primitives (`lv_screen_load_anim`, `lv_layer_top`, `lv_obj_clean`).
+The `View` trait is a navigation-aware lifecycle, and a `Navigator`
+manages a stack of views with push/pop transitions and modal overlays,
+built on LVGL's screen and layer primitives (`lv_screen_load_anim`,
+`lv_layer_top`, `lv_obj_clean`).
 
 ---
 
@@ -59,11 +60,10 @@ overlap, the API vision spec takes precedence.
 
 ---
 
-## 3. The `View` Trait (evolved)
+## 3. The `View` Trait
 
-The `View` trait keeps its name but gains new capabilities: repeatable
-`create`, lifecycle hooks, and `NavAction` returns. Every screen of UI
-implements `View`.
+The `View` trait provides a repeatable `create`, lifecycle hooks, and
+`NavAction` returns. Every screen of UI implements `View`.
 
 ```rust
 /// A single view of UI (one screen or modal in a navigation stack).
@@ -72,15 +72,15 @@ implements `View`.
 ///
 /// 1. **Construction** — caller creates the struct (e.g. `Default::default()`)
 /// 2. [`create`] — build widgets into `container`; may be called multiple times
-/// 3. [`did_show`] — post-creation setup (optional)
-/// 4. [`update`] — per-tick polling (runs in render loop)
-/// 5. [`on_event`] — LVGL event dispatch
+/// 3. [`register_events_on`] — attach the event trampoline to `container`
+/// 4. [`did_show`] — post-creation setup (optional)
+/// 5. [`update`] / [`on_event`] — per-tick polling and LVGL event dispatch
 /// 6. [`will_hide`] — save transient state before widget teardown (optional)
 /// 7. Widget tree destroyed (navigator calls `lv_obj_clean`)
 ///
 /// Steps 2–7 repeat on each push/pop cycle for views that remain on
 /// the stack.
-pub trait View: 'static {
+pub trait View: Sized + 'static {
     /// Build all LVGL widgets for this view into `container`.
     ///
     /// Called each time this view becomes the active (topmost) view —
@@ -154,36 +154,12 @@ pub trait View: 'static {
 }
 ```
 
-### 3.1 Key Changes from Current `View`
+### 3.1 Single-View Usage
 
-| Aspect | Current `View` | Evolved `View` |
-|---|---|---|
-| Construction | `create() -> Result<Self>` | Caller constructs struct; `create(&mut self, container)` builds widgets |
-| Widget rebuilding | Not possible (create runs once) | `create` called on every push/pop return |
-| Lifecycle hooks | None | `will_hide`, `did_show` |
-| Bound | `Sized` | `'static` (must live on navigator stack) |
-| Active screen access | `lv_screen_active()` in create | `container` parameter passed by navigator |
-| `update` return | `Result<(), WidgetError>` | `Result<NavAction, WidgetError>` |
-
-### 3.2 Migration for Single-View Examples
-
-For the common case of a single-screen example, the migration is
-mechanical:
+A single-screen example implements `View` directly; the harness pushes it
+as the root:
 
 ```rust
-// Current View:
-struct MyExample { label: Label<'static> }
-impl View for MyExample {
-    fn create() -> Result<Self, WidgetError> {
-        let scr = Screen::active().unwrap();
-        let label = Label::new(&scr)?;
-        Ok(Self { label })
-    }
-    fn update(&mut self) -> Result<(), WidgetError> { Ok(()) }
-}
-example_main!(MyExample);
-
-// Evolved View:
 #[derive(Default)]
 struct MyExample { label: Option<Label<'static>> }
 impl View for MyExample {
@@ -195,9 +171,9 @@ impl View for MyExample {
 example_main!(MyExample::default());
 ```
 
-Widget fields become `Option<W>` because the struct exists before
-`create` is called. `#[derive(Default)]` eliminates manual `None`
-initialization. The `example_main!` macro accepts an expression that
+Widget fields are `Option<W>` because the struct exists before `create`
+is called, and `create` may run again after a pop. `#[derive(Default)]`
+supplies the initial `None`s. `example_main!` takes an expression that
 produces the initial view instance.
 
 ---
@@ -229,7 +205,11 @@ pub struct Navigator {
     // lv_layer_sys(). See §4.3.
     toast: Option<Box<dyn AnyView>>,
     toast_container: Option<Obj<'static>>,
-    toast_deadline: Option<Instant>,
+    // Auto-dismiss deadline in wrap-aware tick milliseconds (`get_tick_ms`),
+    // not `Instant`. See §4.3.
+    toast_deadline_ms: Option<u32>,
+    // FIFO of timed toasts waiting behind the active one (capacity 4).
+    toast_queue: VecDeque<PendingToast>,
 }
 ```
 
@@ -237,27 +217,35 @@ pub struct Navigator {
 
 ```rust
 impl Navigator {
-    /// Push a new view onto the stack.
+    /// Push the root view. Called once at startup (by `run_app_nav`); the
+    /// root gets its own created + loaded screen so pop-to-root and toast
+    /// re-parenting are uniform.
+    pub fn push_root(&mut self, view: impl View);
+
+    /// Push a new view onto the stack. Each view owns its own
+    /// `Obj<'static>` screen (via `Screen::create`), so the previous
+    /// screen's tree is destroyed *after* the new one is built.
     ///
     /// 1. Calls `will_hide()` on the current top view.
-    /// 2. Destroys the current view's widget tree (`lv_obj_clean`).
-    /// 3. Stores the current view (state preserved, widgets gone).
-    /// 4. Calls `create(container)` on the new view.
-    /// 5. Registers the event trampoline.
-    /// 6. Calls `did_show()` on the new view.
+    /// 2. Creates and loads a new screen, then calls `create(container)`
+    ///    and `register_events_on(container)` on the new view.
+    /// 3. Re-parents any active toast onto the new screen.
+    /// 4. Destroys the previous view's widget tree (`lv_obj_clean`) — its
+    ///    struct state stays on the stack.
+    /// 5. Calls `did_show()` on the new view.
     ///
     /// `anim` controls the screen transition animation. Pass `None` for
     /// an instant switch.
     pub fn push(&mut self, view: impl View, anim: Option<ScreenAnim>);
 
-    /// Pop the current view and return to the previous one.
+    /// Pop the current view and return to the previous one. The restored
+    /// view's screen is loaded and its widgets rebuilt via `create`; the
+    /// popped view's screen is cleaned up afterward.
     ///
-    /// 1. Calls `will_hide()` on the current top view.
-    /// 2. Destroys the current view's widget tree.
-    /// 3. Drops the current view entirely (removed from stack).
-    /// 4. Calls `create(container)` on the now-top view (rebuild widgets).
-    /// 5. Registers the event trampoline.
-    /// 6. Calls `did_show()` on the restored view.
+    /// 1. Loads the restored view's screen and rebuilds it (`create`,
+    ///    `register_events_on`), re-parenting any active toast onto it.
+    /// 2. Drops the popped view and destroys its widget tree.
+    /// 3. Calls `did_show()` on the restored view.
     ///
     /// Returns `Err(NavigationError::StackEmpty)` if only one view
     /// remains (the root view cannot be popped).
@@ -527,6 +515,10 @@ pub enum NavAction {
 }
 ```
 
+Convenience constructors reduce boilerplate: `NavAction::push(view)`,
+`NavAction::replace(view)`, `NavAction::modal(view)`,
+`NavAction::show_toast(view, duration)`, plus `NavAction::is_none()`.
+
 Both `update` and `on_event` return `NavAction`:
 
 ```rust
@@ -582,90 +574,53 @@ point agnostic to how data arrives. oxivgl provides `run_app`,
 `View`, and `Navigator`; the application provides the event
 infrastructure and the tasks that feed it.
 
-To reduce latency when events arrive between render ticks, `run_app`
-accepts an **async wake closure** (see §5.2) that is raced against the
-inter-tick timer, short-circuiting the sleep when the closure resolves.
+To reduce latency when events arrive between render ticks, the
+event-driven entry point `run_app_nav_keypad_events` accepts an **async
+wake closure** (see §5.2) that is raced against the inter-tick timer,
+short-circuiting the sleep when the closure resolves.
 
-### 5.2 `run_app`
+### 5.2 The `run_app` family
 
-Replaces `run_lvgl`. Initializes LVGL, creates the navigator with an
-initial screen, and runs the render loop.
+Each entry point initializes LVGL, builds the render loop, and never
+returns. There is no single universal `run_app(...wake...)`; the shape
+depends on whether the app navigates and how input arrives:
 
 ```rust
-/// Run the LVGL application with navigation support.
-///
-/// This is an embassy async task. Spawn it alongside your other
-/// application tasks. It initializes LVGL, pushes `initial` as the
-/// root screen, and loops forever: calling `update`, driving
-/// `lv_timer_handler`, and processing navigation actions.
-///
-/// `wake` is an async closure called each render tick and raced against
-/// the inter-tick timer. If `wake` resolves before the timer, `run_app`
-/// breaks out of the timer loop early and runs `update()` immediately,
-/// reducing worst-case event-to-screen latency from ~33ms to
-/// near-instant. For timer-only operation, pass
-/// `async || core::future::pending().await`.
-///
-/// Never returns.
-pub async fn run_app<const BYTES: usize, Fut: Future<Output = ()>>(
-    w: i32,
-    h: i32,
-    bufs: &'static mut LvglBuffers<BYTES>,
-    initial: impl View,
-    wake: impl Fn() -> Fut,
-) -> ! {
-    let driver = LvglDriver::init(w, h);
-    unsafe { lvgl_disp_init(w, h, bufs) };
-    DISPLAY_READY.wait().await;
+/// Single view, no navigation. Ignores NavAction (asserts it is None).
+pub async fn run_app<V: View, const BYTES: usize>(
+    w: i32, h: i32, bufs: &'static mut LvglBuffers<BYTES>, view: V) -> !;
 
-    let mut nav = Navigator::new();
-    nav.push(initial, None);
+/// Navigation entry point: creates the Navigator, pushes `initial` as
+/// the root (`push_root`), and processes NavActions each tick.
+pub async fn run_app_nav<const BYTES: usize>(
+    w: i32, h: i32, bufs: &'static mut LvglBuffers<BYTES>, initial: impl View) -> !;
 
-    const LVGL_TIMER_DELAY: u64 = LV_DEF_REFR_PERIOD as u64 / 4;
+/// Navigation + keypad input (timer-paced).
+pub async fn run_app_nav_keypad<const BYTES: usize>(
+    w: i32, h: i32, bufs: &'static mut LvglBuffers<BYTES>,
+    initial: impl View, keypad: KeypadIndev) -> !;
 
-    loop {
-        // Update active view — polls app state, returns NavAction
-        let action = nav.active_view_mut()
-            .update()
-            .unwrap_or_else(|e| { warn!("view update: {:?}", e); NavAction::None });
-
-        // Update modal if present
-        let modal_action = if let Some(modal) = nav.active_modal_mut() {
-            modal.update()
-                .unwrap_or_else(|e| { warn!("modal update: {:?}", e); NavAction::None })
-        } else {
-            NavAction::None
-        };
-
-        // Drive LVGL timers (processes widget events → on_event → NavAction)
-        for _ in 0..4 {
-            driver.timer_handler();
-
-            // Race the tick timer against the wake closure. If wake
-            // resolves first, break out early to run update() sooner.
-            let timer = Timer::after(Duration::from_millis(LVGL_TIMER_DELAY));
-            match select(timer, wake()).await {
-                Either::First(()) => {},   // normal tick
-                Either::Second(()) => break, // early wake → run update
-            }
-        }
-
-        // Process navigation: on_event actions (collected during timer_handler)
-        // take priority, then update actions.
-        nav.process_pending_event_action();
-        if !nav.has_pending() {
-            nav.process_action(action);
-        }
-        if !nav.has_pending() {
-            nav.process_action(modal_action);
-        }
-    }
-}
+/// Navigation + keypad input, event-driven: `wake` is raced against the
+/// inter-tick timer to run the loop sooner when input arrives.
+pub async fn run_app_nav_keypad_events<const BYTES: usize, Fut: Future<Output = ()>>(
+    w: i32, h: i32, bufs: &'static mut LvglBuffers<BYTES>,
+    initial: impl View, keypad: KeypadIndev, wake: impl Fn() -> Fut) -> !;
 ```
 
-The `wake` closure is called fresh each tick, producing a new future
-to race. It only needs `core::future::Future` — no dependency on any
-specific async runtime or synchronization primitive.
+All navigation variants share one inner loop (`run_app_nav_inner`):
+
+1. `update()` the active view (and the modal, if present), collecting
+   their `NavAction`s.
+2. Drive `lv_timer_handler` four times, each iteration racing the tick
+   timer against `wake()` via `embassy_time::with_timeout`, so an early
+   wake shortens the sleep. Widget events fire here, producing pending
+   `on_event` actions.
+3. `process_pending_event_action()` first — `on_event` actions win over
+   `update` actions in the same tick — then the `update` / modal actions.
+4. `drain_toast_requests()` (cross-task `post_toast`), then `tick_toast()`.
+
+The `wake` closure is called fresh each tick and only needs
+`core::future::Future` — no dependency on a specific async runtime.
 
 ### 5.3 Real Application Example
 
@@ -725,8 +680,9 @@ async fn button_task(back_pin: Input<'static>) {
 
 // Entry point — async closure wakes on signal
 #[embassy_executor::task]
-async fn ui_task(bufs: &'static mut LvglBuffers<BUF_BYTES>) -> ! {
-    run_app(320, 240, bufs, DashboardView::default(),
+async fn ui_task(bufs: &'static mut LvglBuffers<BUF_BYTES>, keypad: KeypadIndev) -> ! {
+    // The event-driven entry point is where the wake closure lives.
+    run_app_nav_keypad_events(320, 240, bufs, DashboardView::default(), keypad,
         async || WAKE.wait().await,
     ).await
 }
@@ -780,22 +736,19 @@ async || BACK_PIN.wait_for_falling_edge().await
 async || core::future::pending().await
 ```
 
-### 5.4 `example_main!` Update
+### 5.4 Harness macros
 
-The macro signature changes to accept an initial screen expression:
+The example harness (`examples/common`) provides three macros, each
+taking an expression that produces the initial view:
 
 ```rust
-// Old:
-example_main!(MyView);
-
-// New:
-example_main!(MyExample::default());
+example_main!(MyExample::default());                    // single view → run_app
+example_main_nav!(RootView::default());                // navigation → run_app_nav
+example_main_psram!(MyExample::default(), 512 * 1024);  // + runtime PSRAM pool
 ```
 
-The macro expands to
-`run_app(W, H, bufs, <expr>, async || core::future::pending().await).await`
-on embedded (timer-only, no external wake) and to the host SDL loop
-with equivalent logic.
+Each expands to the matching `run_app*` call on the selected board
+(`fire27` / `cores3`), or to the host SDL loop with equivalent logic.
 
 ---
 
@@ -807,12 +760,14 @@ stack entries. `AnyView` is an object-safe supertrait of `View`.
 ```rust
 /// Object-safe trait for type-erased views. Not implemented directly
 /// — the blanket impl covers all `View` types.
-pub trait AnyView {
+pub trait AnyView: 'static {
     fn create(&mut self, container: &Obj<'static>) -> Result<(), WidgetError>;
     fn update(&mut self) -> Result<NavAction, WidgetError>;
     fn on_event(&mut self, event: &Event) -> NavAction;
+    fn register_events_on(&mut self, container: &Obj<'static>);
     fn will_hide(&mut self);
     fn did_show(&mut self);
+    fn input_group(&self) -> Option<GroupRef>;
 }
 
 impl<T: View> AnyView for T {
@@ -883,11 +838,11 @@ observer bindings.
 | Active screen handle | `lv_screen_active()` | `Screen::active()` → `Screen` (non-owning) | Exists |
 | Top layer | `lv_layer_top()` | `Screen::layer_top()` → `Child<Obj>` | Exists |
 | Widget teardown | `lv_obj_clean()` | `Obj::clean()` | Exists |
-| New screen object | `lv_obj_create(NULL)` | `Screen::create()` → `Obj<'static>` | **Phase 1** |
-| Full-screen transition | `lv_screen_load_anim()` | `Screen::load()` | **Phase 1** |
-| Instant screen switch | `lv_screen_load()` | `Screen::load()` (with `ScreenAnimType::None`) | **Phase 1** |
-| System layer | `lv_layer_sys()` | `Screen::layer_sys()` → `Child<Obj>` | **Phase 1** |
-| Screen anim types | `lv_screen_load_anim_t` | `ScreenAnimType` enum | **Phase 1** |
+| New screen object | `lv_obj_create(NULL)` | `Screen::create()` → `Obj<'static>` | Shipped |
+| Full-screen transition | `lv_screen_load_anim()` | `Screen::load(scr, anim, auto_del)` | Shipped |
+| Instant screen switch | `lv_screen_load()` | `Screen::load_instant(scr)` | Shipped |
+| System layer | `lv_layer_sys()` | `Screen::layer_sys()` → `Child<Obj>` | Shipped |
+| Screen anim types | `lv_screen_load_anim_t` | `ScreenAnimType` enum | Shipped |
 
 `Screen` is the namespace for LVGL's screen concept. It has two roles:
 
@@ -905,64 +860,26 @@ No deprecated or experimental LVGL APIs are used.
 
 ---
 
-## 9. Migration Plan
+## 9. Implementation Status
 
-### Phase 1: Prerequisites (additive, build stays green)
-
-Add screen lifecycle wrappers to `src/widgets/screen.rs`:
-- `Screen::create() -> Obj<'static>` — wraps `lv_obj_create(NULL)`,
-  returns an owned screen object for Navigator to manage
-- `Screen::load(obj, anim)` — wraps `lv_screen_load_anim`, takes
-  any `&impl AsLvHandle`
-- `Screen::layer_sys()` — wraps `lv_layer_sys`, same pattern as
-  existing `layer_top()`
-- `ScreenAnimType` enum mirroring `lv_screen_load_anim_t`
-- `ScreenAnim` struct (type + duration + delay)
-
-### Phase 2: Core Implementation
-
-1. Evolve `View` trait in `src/view.rs` with new method signatures.
-2. Add `AnyView` trait with blanket impl.
-3. Add `Navigator` struct with push/pop/replace/modal.
-4. Add `NavAction` enum.
-5. Replace `run_lvgl` with `run_app` in `src/view.rs`.
-6. Update `example_main!` macro.
-
-### Phase 3: Validation
-
-Port one complex multi-state example to evolved `View` + `Navigator`:
-- `observer5.rs` (firmware update state machine) — currently simulates
-  multi-screen behavior with manual widget teardown and rebuilding.
-  Natural fit for push/pop.
-
-Port one simple single-screen example to verify the mechanical
-migration path works cleanly.
-
-### Phase 4: Full Migration
-
-1. Port all remaining examples to evolved `View` signatures.
-2. Remove `run_lvgl` and old `register_view_events`.
-3. Update all documentation.
-
-### Phase 5: Extend
-
-- Write a multi-screen example (e.g. menu → settings → back).
-- Write a modal example (e.g. confirmation dialog).
-- Add integration tests for push/pop/modal lifecycle.
-- Add a leak test for navigator teardown.
+Fully shipped. Reference examples: `nav1.rs` (two-screen push/pop),
+`toast_hil_demo.rs` (toasts), `menu_keypad.rs` (keypad-navigated menu).
 
 ---
 
 ## 10. Error Types
 
 ```rust
-/// Errors from navigation operations.
+/// Errors from navigation operations. Implements `Debug` and `Display`.
+#[derive(Debug)]
 pub enum NavigationError {
     /// Cannot pop the root screen.
     StackEmpty,
     /// No modal is currently active.
     NoActiveModal,
-    /// Screen creation failed.
+    /// No toast is currently active.
+    NoActiveToast,
+    /// View creation failed during a navigation transition.
     CreateFailed(WidgetError),
 }
 ```
@@ -989,27 +906,10 @@ The current spec does not define animation for modal show/dismiss.
 animations would need to use `lv_anim_*` on the backdrop/content
 objects directly.
 
-**Recommendation**: defer. Implement instant modal show/dismiss first.
-Add animation support when needed.
+**Recommendation**: modal show/dismiss is instant today; animation
+remains deferred. Full-screen transitions do animate via `ScreenAnim`.
 
-### 11.3 `NavAction` Ergonomics
-
-Returning `NavAction` from `on_event` is explicit but slightly
-inconvenient for views that never navigate. The default implementation
-returns `NavAction::None`, so non-navigating views don't need to
-override `on_event` at all. For navigating screens, a helper constructor
-pattern reduces boilerplate:
-
-```rust
-fn on_event(&mut self, event: &Event) -> NavAction {
-    if event.matches(&self.settings_btn, EventCode::CLICKED) {
-        return NavAction::push(SettingsView::default());
-    }
-    NavAction::None
-}
-```
-
-### 11.4 Background View `update`
+### 11.3 Background View `update`
 
 Only the active (topmost) full-screen view and the modal get `update`
 calls. Views lower in the stack do not receive `update` while hidden.
@@ -1037,5 +937,5 @@ channel / `watch`) for high-frequency data like sensor readings.
 | `Rc` not `Arc` | `spec-memory-lifetime.md` §4.3 | Navigator is single-task; no `Send`/`Sync` required |
 | Thin wrappers | `spec-api-vision.md` §3 | Navigator maps directly to `lv_screen_load_anim` + `lv_layer_top` |
 | `no_std` + `alloc` | `spec-api-vision.md` §4 | Uses `Vec`, `Box` from `alloc` (already a dependency) |
-| Zero warnings | `spec-rust-code.md` §2 | All types fully documented; no `#[allow()]` |
+| Zero warnings | `CLAUDE.md` (zero-warnings policy) | All types fully documented; no `#[allow()]` |
 | Hardware input via channels | §5.1, §5.3 | Button/sensor tasks send events through embassy channels; `update()` polls; no GPIO interrupts or LVGL indev required |

--- a/docs/spec-widget-wrapper.md
+++ b/docs/spec-widget-wrapper.md
@@ -85,8 +85,9 @@ invariant.
 
 ## 7. Doc Comments
 
-Every public type and method must have `///` doc comments. CI enforces
-this via `-W missing-docs`. Include a brief description of what the
+Every public type and method must have `///` doc comments. The audit is
+`./run_docs.sh --check` (it catches `error:` and build failures, not just
+`warning:`). Include a brief description of what the
 LVGL function does and any constraints (e.g. value ranges, required
 config flags).
 

--- a/examples/doc/README.md
+++ b/examples/doc/README.md
@@ -3,7 +3,9 @@
 LVGL example screens ported from the [LVGL docs](https://docs.lvgl.io/9.5/examples.html).
 
 Each example is a self-contained file with a `View` impl and a cfg-gated
-runner (`example_main!` macro selects host SDL2 or ESP32 fire27 backend).
+runner (`example_main!` / `example_main_nav!` / `example_main_psram!` macros
+select host SDL2 or an ESP32 board backend — `fire27` (ESP32) or `cores3`
+(ESP32-S3)).
 
 ## Contents
 

--- a/src/render_scratch.rs
+++ b/src/render_scratch.rs
@@ -26,11 +26,12 @@
 //! or `LV_STDLIB_BUILTIN` with no pool registered — the calls delegate straight
 //! to LVGL's allocator, so behaviour is byte-for-byte unchanged.
 //!
-//! Only *transient* per-frame scratch is routed. LVGL's gradient and
-//! circle-mask *caches* — allocated once and read across frames, and freed
-//! cross-function — are intentionally left on LVGL's allocator: they are not the
-//! per-frame churn this targets, and their alloc/free pairing does not fit the
-//! single-regime invariant below.
+//! Both the transient per-frame scratch and the radius/circle mask cache
+//! (`lv_draw_sw_mask.c`, read per-scanline every frame by arc, rounded-rect,
+//! border and shadow draws) are routed — the mask cache is safe to route because
+//! all of its alloc/free sites are lexically inside that one file, so both ends
+//! move together. LVGL's gradient cache (`lv_draw_sw_grad.c`) is left on LVGL's
+//! allocator: gradient-only and cross-function with multi-path frees.
 
 use core::ffi::c_void;
 use core::sync::atomic::{AtomicBool, Ordering};


### PR DESCRIPTION
Docs-quality pass: resolves #123 and re-sweeps the doc set for staleness against the shipped v0.6.x code.

Stacked on #125 (carries the v0.6.1 render-scratch context); retargets to `master` when #125 merges.

## #123 — navigation spec reconciled with the shipped API
`docs/spec-navigation.md` was a Draft implementation *plan* for a feature that has shipped. Turned it into a specification of what exists (1041 → 941 lines):
- **Removed migration cruft**: §3.1 "Key Changes from Current View" table, §3.2 single-view migration guide, the entire §9 Migration Plan (Phases 1–5), and the resolved §11.3 NavAction-ergonomics question (constructors shipped). Status Draft → Implemented.
- **Corrected API divergences** against `src/view.rs` / `src/navigator.rs` / `src/widgets/screen.rs`: the `run_app` family (there is no unified `run_app(...wake...)` — `run_app` is single-view, navigation is `run_app_nav` + keypad variants); lifecycle order (`register_events_on` before `did_show`); `View: Sized + 'static`; `toast_deadline_ms: u32` + the `toast_queue` field; `AnyView`'s `register_events_on`/`input_group`; `NavigationError::NoActiveToast`; `push_root` + per-view owned screens; `Screen::load_instant`; `example_main!` vs `_nav!` vs `_psram!`; §8 "Phase 1" → Shipped. Added the shipped `NavAction` constructors; fixed a dangling ref to a non-existent `spec-rust-code.md`.

## Staleness sweep (rest of the doc set)
- **`src/render_scratch.rs`** — module doc said the circle-mask cache is left on LVGL's allocator; it's now routed (`sw_mask.c`). Corrected. (Private module → not on docs.rs, so this isn't a 0.6.1 release blocker.)
- **README** — embedded check command lacked a chip feature/target (wouldn't compile); Features table missing `esp32`/`esp32s3`/`png` + the `fire27`/`cores3` board features.
- **spec-example-porting** — `example_main!` takes a view *expression*; §4 `create`/`update`/`register_events` described the pre-navigation `View`; doc-check pointed at raw `cargo doc` instead of `./run_docs.sh --check`.
- **spec-widget-wrapper** — same doc-check correction.
- **spec-memory-lifetime** — added §13 covering the `mem` runtime-pool and `render_scratch` guards and their lifetime contracts.
- **memory-tuning / examples-doc / cr-navigator** — note render scratch stays internal under a pool; mention `cores3` and the runtime PSRAM pool.

`spec-api-vision.md` and `tools/README.md` audited clean.

Doc audit (`run_docs.sh --check`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
